### PR TITLE
Travis: disable npm caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: node_js
 node_js:
   - "10"
+cache:
+  npm: false
+
 
 services:
   - docker


### PR DESCRIPTION
As of July 2019, [Travis automatically caches npm](https://docs.travis-ci.com/user/caching/#npm-cache). This can sometimes cause depfu builds to fail. The travis script has been updated to explicitly disable npm caching.