### PR TITLE
fix: player-area ios safari compat

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
     />
     <meta name="theme-color" content="#000000" />
     <!--
@@ -26,7 +26,7 @@
   </head>
   <body id="body">
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root" style="touch-action: manipulation;"></div>
     <div id="modal"></div>
     <!--
       This HTML file is a template.

--- a/src/hooks/use-long-press.js
+++ b/src/hooks/use-long-press.js
@@ -11,6 +11,7 @@ export const useLongPress = (callback = () => {}, ms = 300) => {
   const timeoutRef = useRef(null);
 
   const onMouseDown = useCallback(ev => {
+    if (ev.touches && ev.touches.length === 2) return;
     ev.persist();
     timeoutRef.current = setTimeout(() => {
       timeoutRef.current = null;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,20 @@ import "./style.css";
 
 const element = document.querySelector("#root");
 
+//
+// hack for disabling pinch zoom in Safari
+// Unfortunately, Safari does ignore the following HTML meta tags...
+// maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, shrink-to-fit=no
+if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+  window.addEventListener(
+    "touchstart",
+    ev => {
+      ev.preventDefault();
+    },
+    { passive: false }
+  );
+}
+
 const main = async () => {
   let component = null;
   switch (window.location.pathname) {

--- a/src/pan-zoom.js
+++ b/src/pan-zoom.js
@@ -1,0 +1,244 @@
+import React from "react";
+import { SpringValue, to, animated } from "react-spring";
+import { useResetState } from "./hooks/use-reset-state";
+
+const noopStyle = {};
+
+const innerStyles = {
+  transformOrigin: "0 0 0",
+  willChange: "transform",
+  backfaceVisibility: "hidden",
+  WebkitBackfaceVisibility: "hidden",
+  display: "inline-block"
+};
+
+const ZOOM_SPEED_MULTIPLIER = 0.065;
+
+const getScaleMultiplier = (delta, zoomSpeed = 1) => {
+  const speed = ZOOM_SPEED_MULTIPLIER * zoomSpeed;
+  let scaleMultiplier = 1;
+  if (delta > 0) {
+    // zoom out
+    scaleMultiplier = 1 - speed;
+  } else if (delta < 0) {
+    // zoom in
+    scaleMultiplier = 1 + speed;
+  }
+
+  return scaleMultiplier;
+};
+
+export const PanZoom = React.forwardRef(
+  (
+    {
+      translate: _translate,
+      scale: _scale,
+      style = noopStyle,
+      children,
+      minZoom = 0,
+      maxZoom = Infinity,
+      zoomSpeed = 1,
+      ...props
+    },
+    ref
+  ) => {
+    const containerRef = React.useRef(null);
+    const dragContainerRef = React.useRef(null);
+    const [translate] = useResetState(
+      () => _translate || new SpringValue([0, 0]),
+      [_translate]
+    );
+
+    const [scale] = useResetState(() => _scale || new SpringValue(1), [_scale]);
+    const transform = to(
+      [scale, translate],
+      (scale, [x, y]) => `translate(${x}px, ${y}px) scale(${scale})`
+    );
+
+    const getOffset = React.useCallback(ev => {
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const offsetX = ev.clientX - containerRect.left;
+      const offsetY = ev.clientY - containerRect.top;
+      return { x: offsetX, y: offsetY };
+    }, []);
+
+    const zoomTo = React.useCallback(
+      ({ x, y, ratio }) => {
+        const [transformX, transformY] = translate.get();
+        let newScale = scale.get() * ratio;
+        if (newScale < minZoom) {
+          if (scale === minZoom) {
+            return;
+          }
+          ratio = minZoom / scale;
+          newScale = minZoom;
+        } else if (newScale > maxZoom) {
+          if (scale === maxZoom) {
+            return;
+          }
+          ratio = maxZoom / scale;
+          newScale = maxZoom;
+        }
+
+        const newX = x - ratio * (x - transformX);
+        const newY = y - ratio * (y - transformY);
+        translate.set([newX, newY]);
+        scale.set(newScale);
+      },
+      [scale, translate, minZoom, maxZoom]
+    );
+
+    const centeredZoom = React.useCallback(
+      ({ delta, speed = zoomSpeed }) => {
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const ratio = getScaleMultiplier(delta, speed);
+        zoomTo({
+          x: containerRect.width / 2,
+          y: containerRect.height / 2,
+          ratio
+        });
+      },
+      [zoomSpeed, zoomTo]
+    );
+
+    React.useEffect(() => {
+      const onWheel = ev => {
+        const ratio = getScaleMultiplier(ev.deltaY, zoomSpeed);
+        const { x, y } = getOffset(ev);
+        zoomTo({ x, y, ratio });
+        ev.preventDefault();
+        ev.stopPropagation();
+      };
+
+      const node = containerRef.current;
+      node.addEventListener("wheel", onWheel, {
+        passive: false
+      });
+
+      return () => {
+        node.removeEventListener("wheel", onWheel, {
+          passive: false
+        });
+      };
+    }, [scale, zoomSpeed, zoomTo, getOffset]);
+
+    React.useEffect(() => {
+      ref.current = {
+        zoomIn: speed => {
+          centeredZoom({ delta: -1, speed });
+        },
+        zoomOut: speed => {
+          centeredZoom({ delta: 1, speed });
+        },
+        autoCenter: (zoomLevel = 1) => {
+          const containerRect = containerRef.current.getBoundingClientRect();
+          const dragContainer = dragContainerRef.current;
+          const { clientWidth, clientHeight } = dragContainer;
+          const widthRatio = containerRect.width / clientWidth;
+          const heightRatio = containerRect.height / clientHeight;
+
+          const newScale = Math.min(widthRatio, heightRatio) * zoomLevel;
+
+          const x = (containerRect.width - clientWidth * newScale) / 2;
+          const y = (containerRect.height - clientHeight * newScale) / 2;
+          translate.set([x, y]);
+          scale.set(newScale);
+        },
+        getDragContainer: () => dragContainerRef.current
+      };
+    });
+
+    return (
+      <div
+        ref={containerRef}
+        style={{
+          ...style,
+          transformStyle: "preserve-3d",
+          WebkitTransformStyle: "preserve-3d"
+        }}
+        onDoubleClick={ev => {
+          zoomTo({ x: ev.clientX, y: ev.clientY, ratio: 2 });
+        }}
+        onMouseDown={ev => {
+          if (props.onMouseDown) props.onMouseDown(ev);
+          const bounds = dragContainerRef.current.getBoundingClientRect();
+          const offsetX = ev.clientX - bounds.x;
+          const offsetY = ev.clientY - bounds.y;
+
+          const onMouseMove = ev => {
+            translate.set([ev.clientX - offsetX, ev.clientY - offsetY]);
+          };
+
+          const onMouseUp = () => {
+            window.removeEventListener("mousemove", onMouseMove);
+            window.removeEventListener("mouseup", onMouseUp);
+          };
+          window.addEventListener("mousemove", onMouseMove);
+          window.addEventListener("mouseup", onMouseUp);
+        }}
+        onTouchStart={ev => {
+          if (props.onTouchStart) props.onTouchStart(ev);
+          const bounds = dragContainerRef.current.getBoundingClientRect();
+          const offsetX = ev.touches[0].clientX - bounds.x;
+          const offsetY = ev.touches[0].clientY - bounds.y;
+
+          let onTouchMove = ev => {
+            if (ev.touches.length === 2) {
+              return;
+            } else {
+              translate.set([
+                ev.touches[0].clientX - offsetX,
+                ev.touches[0].clientY - offsetY
+              ]);
+            }
+          };
+
+          if (ev.touches.length === 2) {
+            const xCenter = (ev.touches[0].clientX + ev.touches[1].clientX) / 2;
+            const yCenter = (ev.touches[0].clientY + ev.touches[1].clientY) / 2;
+
+            let previousDiff = Math.hypot(
+              ev.touches[0].clientX - ev.touches[1].clientX,
+              ev.touches[0].clientY - ev.touches[1].clientY
+            );
+
+            onTouchMove = ev => {
+              if (ev.touches.length === 2) {
+                const newDiff = Math.hypot(
+                  ev.touches[0].clientX - ev.touches[1].clientX,
+                  ev.touches[0].clientY - ev.touches[1].clientY
+                );
+                if (newDiff === previousDiff) return;
+                zoomTo({
+                  x: xCenter,
+                  y: yCenter,
+                  ratio: newDiff > previousDiff ? 1.03 : 0.97
+                });
+                previousDiff = newDiff;
+              }
+            };
+          }
+
+          const onTouchEnd = () => {
+            window.removeEventListener("touchmove", onTouchMove);
+            window.removeEventListener("touchend", onTouchEnd);
+          };
+
+          window.addEventListener("touchmove", onTouchMove);
+          window.addEventListener("touchend", onTouchEnd);
+        }}
+      >
+        <animated.div
+          ref={dragContainerRef}
+          style={{
+            ...innerStyles,
+            transform,
+            WebkitTransform: transform
+          }}
+        >
+          {children}
+        </animated.div>
+      </div>
+    );
+  }
+);

--- a/src/player-area.js
+++ b/src/player-area.js
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useEffect, useCallback } from "react";
 import produce from "immer";
 import createPersistedState from "use-persisted-state";
-import { PanZoom } from "react-easy-panzoom";
+import { PanZoom } from "./pan-zoom";
 import Referentiel from "referentiel";
 import useAsyncEffect from "@n1ru4l/use-async-effect";
 import { loadImage, getOptimalDimensions } from "./util";
@@ -226,8 +226,8 @@ const PlayerMap = ({ fetch, pcPassword }) => {
             const canvasDimensions = getOptimalDimensions(
               map.width,
               map.height,
-              Math.max(window.innerWidth, 3000),
-              Math.max(window.innerHeight, 9000)
+              Math.min(window.innerWidth * 3, 3000),
+              Math.min(window.innerHeight * 3, 9000)
             );
 
             mapCanvas.width = canvasDimensions.width;
@@ -425,6 +425,10 @@ const PlayerMap = ({ fetch, pcPassword }) => {
               <Toolbar.Item isActive>
                 <Toolbar.Button
                   onClick={() => {
+                    centerMap();
+                  }}
+                  onTouchStart={ev => {
+                    ev.preventDefault();
                     centerMap();
                   }}
                 >


### PR DESCRIPTION
The app was a mess on an iPad. Safari is horrible, I had to reimplement how to pinch-zoom works on touch devices... Ended up writing a new PanZoom view. I also reduced the maximum map size, as iPhones and iPads were constantly crashing due to out-of-memory issues. I also removed the zoom animations (when holding the zoom in and zoom out buttons), because it also caused some buggy behavior, I do not think that their absence is that bad.

Also updates react-spring to a 9.0.0 canary version which has a nice feature (SpringValue, basically a two-way data binding for style attributes) that really helped me with keeping the style updates performant.

I tested it on an iPad with iOS 13, Google Chrome (Desktop), Google Chrome (Tablet Mode) and Safari Desktop. Everything seemed to work fine. If anyone else here has an Android Tablet and could double-check I would really appreciate it!.

The plan is to improve this new PanZoom implementation, so it can one day replace the PanZoom implementation in the DM Section (which ultimately would make the DM Section also iPad friendly). However, currently, my motivation is just to provide the players with the possibility to follow the map on an iPad.


_____

Closes #130