### PR TITLE
Travis: Add build for ARMv7 architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - "10"
@@ -27,7 +26,7 @@ jobs:
     - stage: build docker image
       install: true
       script:
-        - docker build -t dungeon-revealer .
+        - docker build -t dungeon-revealer -f Dockerfile .
         - docker run --rm dungeon-revealer echo "hello"
 
     - stage: dockerhub dev deploy
@@ -40,10 +39,22 @@ jobs:
         - docker push $DOCKER_USERNAME/dungeon-revealer
 
     - stage: github deploy
+      install:
+        - yarn install
+        - sudo docker run --rm --privileged multiarch/qemu-user-static:register
+        - wget https://github.com/multiarch/qemu-user-static/releases/download/v4.1.1-1/qemu-arm-static.tar.gz -O /tmp/qemu-arm-static.tar.gz
+        - tar zxvf /tmp/qemu-arm-static.tar.gz -C /tmp
+        - docker build -t dr-armbuild -f Dockerfile-armbuild .
       script:
         - echo "Deploying $TRAVIS_TAG to GitHub releases ..."
-        - chmod +x bin/dungeon-revealer-linux bin/dungeon-revealer-macos
+        - echo "Building x64 binaries..."
+        - yarn compilex64
+        - echo "Building armv7 binaries..."
+        - sudo docker run --rm -v /tmp/qemu-arm-static:/usr/bin/qemu-arm-static -v $(pwd)/bin/:/usr/src/app/bin/ dr-armbuild /bin/sh -c 'yarn install; yarn compilearm'
+        - cp bin/arm/dungeon-revealer bin/dungeon-revealer-linux-armv7
+        - chmod +x bin/dungeon-revealer-linux bin/dungeon-revealer-macos bin/dungeon-revealer-linux-armv7
         - zip "dungeon-revealer-linux-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-linux README.md
+        - zip "dungeon-revealer-linux-armv7-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-linux-armv7 README.md
         - zip "dungeon-revealer-macos-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-macos README.md
         - zip "dungeon-revealer-win-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-win.exe README.md
       deploy:
@@ -51,6 +62,7 @@ jobs:
         api_key: $GITHUB_OAUTH_TOKEN
         file:
           - "dungeon-revealer-linux-$TRAVIS_TAG.zip"
+          - "dungeon-revealer-linux-armv7-$TRAVIS_TAG.zip"
           - "dungeon-revealer-macos-$TRAVIS_TAG.zip"
           - "dungeon-revealer-win-$TRAVIS_TAG.zip"
         skip_cleanup: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,12 @@ Run the react development server:
 Run the backend:
 
 - `yarn start` (available on `localhost:3000`)
+
+Compile executables:
+
+- `yarn compilex64` for x64 machines (most computers).
+- `yarn compilearm` for armv7 machines (Raspberry Pi and other single board computers).
+
+The executables are located in the bin folder.
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ COPY . .
 # Docker runs the app as root inside the container, 
 # so it needs elevated permissions.
 # Remove binaries after install since we don't need them.
-RUN yarn install && rm bin/dungeon-revealer-*
+RUN yarn install 
 
 CMD [ "yarn", "start" ]

--- a/Dockerfile-armbuild
+++ b/Dockerfile-armbuild
@@ -1,0 +1,7 @@
+FROM arm32v7/node:dubnium-jessie
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+CMD ["yarn", "install"]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "start": "node ./bin/dungeon-revealer",
     "eslint": "eslint --ignore-path .gitignore --max-warnings 0 \"**/*.js\" \"bin/dungeon-revealer\"",
     "start:dev": "cross-env PORT=3001 EXTEND_ESLINT=true react-scripts start",
-    "build": "react-scripts build && pkg . --out-path ./bin/ --targets node10-win-x64,node10-macos-x64,node10-linux-x64",
+    "build": "react-scripts build",
+    "compilex64": "pkg . --out-path ./bin/ --targets node10-win-x64,node10-macos-x64,node10-linux-x64",
+    "compilearm": "pkg . --out-path ./bin/arm/ --targets node10-linux-armv7",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "postinstall": "npm run build"


### PR DESCRIPTION
This adds the ability for travis-ci to build an executable for the armv7 architecture, most popularly used in the Raspberry Pi. See issue #256. The travis servers run on x86/64 machines incapable of producing arm binaries. You have to emulate an arm machine to build the binary in.

This pull request does three things:
- In package.json, separate the binary compilation commands from the build script allowing a choice between architectures.
- Setup the travis build environment to emulate arm using qemu. Mostly adapted from [here](https://developer.ibm.com/linuxonpower/2017/07/28/travis-multi-architecture-ci-workflow/).
- Compile the arm executable in an [arm docker container](https://hub.docker.com/r/arm32v7/node).

The new scripts for compilation of binaries are needed because the build will fail if attempting to compile for a target architecture that is incompatible with the host. For example, `pkg . --out-path ./bin --targets node10-linux-armv7` will fail on an x64 machine and vice versa.