### PR TITLE
fix(player-area): show splash screen when no map is shared with the players

### DIFF
--- a/src/dm-area/index.js
+++ b/src/dm-area/index.js
@@ -17,7 +17,7 @@ import { SetMapGrid } from "./set-map-grid";
 import { useSocket } from "../socket";
 import { useStaticRef } from "../hooks/use-static-ref";
 import { AuthenticationScreen } from "../authentication-screen";
-import { LoadingScreen } from "../loading-screen";
+import { SplashScreen } from "../splash-screen";
 
 const useLoadedMapId = createPersistedState("loadedMapId");
 const useDmPassword = createPersistedState("dmPassword");
@@ -282,7 +282,7 @@ export const DmArea = () => {
   }, [loadedMapId]);
 
   if (mode.title === "LOADING") {
-    return <LoadingScreen />;
+    return <SplashScreen text="Loading...." />;
   }
 
   if (mode.title === "AUTHENTICATE") {

--- a/src/player-area.js
+++ b/src/player-area.js
@@ -13,7 +13,7 @@ import * as Icons from "./feather-icons";
 import { useSocket } from "./socket";
 import { AreaMarkerRenderer } from "./object-layer/area-marker-renderer";
 import { TokenRenderer } from "./object-layer/token-renderer";
-import { LoadingScreen } from "./loading-screen";
+import { SplashScreen } from "./splash-screen";
 import { AuthenticationScreen } from "./authentication-screen";
 
 const ToolbarContainer = styled.div`
@@ -24,6 +24,14 @@ const ToolbarContainer = styled.div`
   bottom: 0;
   bottom: 12px;
   pointer-events: none;
+`;
+
+const AbsoluteFullscreenContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 `;
 
 const reduceOffsetToMinimum = (offset, sideLength) => {
@@ -479,7 +487,11 @@ const PlayerMap = ({ fetch, pcPassword }) => {
             </Toolbar.Group>
           </Toolbar>
         </ToolbarContainer>
-      ) : null}
+      ) : (
+        <AbsoluteFullscreenContainer>
+          <SplashScreen text="Ready." />
+        </AbsoluteFullscreenContainer>
+      )}
     </>
   );
 };
@@ -523,7 +535,7 @@ export const PlayerArea = () => {
   );
 
   if (mode === "LOADING") {
-    return <LoadingScreen />;
+    return <SplashScreen text="Loading..." />;
   }
   if (mode === "AUTHENTICATE") {
     return (

--- a/src/splash-screen.js
+++ b/src/splash-screen.js
@@ -1,13 +1,20 @@
 import React from "react";
 import { BackgroundImageContainer } from "./background-image-container";
 import { BrandLogoText } from "./brand-logo-text";
+import styled from "@emotion/styled/macro";
 
-export const LoadingScreen = () => {
+const SplashScreenText = styled.div`
+  text-align: center;
+  font-size: 20px;
+  font-weight: bold;
+`;
+
+export const SplashScreen = ({ text = null }) => {
   return (
     <BackgroundImageContainer>
       <div>
         <BrandLogoText />
-        <div>Loading....</div>
+        <SplashScreenText>{text}</SplashScreenText>
       </div>
     </BackgroundImageContainer>
   );


### PR DESCRIPTION
Currently, the players only see a black screen when no map is shared.