### PR TITLE
feat: allow configuring the host on which dungeon-revealer will listen for http requests

### DIFF
--- a/bin/dungeon-revealer
+++ b/bin/dungeon-revealer
@@ -8,8 +8,9 @@ const os = require("os");
 const ifaces = os.networkInterfaces();
 
 app.set("port", process.env.PORT || 3000);
+app.set("host", process.env.HOST || "0.0.0.0");
 
-const server = http.listen(app.get("port"), () => {
+const server = http.listen(app.get("port"), app.get("host"), () => {
   const port = server.address().port;
   const baseAddress = `http://localhost:${port}`;
 


### PR DESCRIPTION
... via the HOST environment variable.

Closes #289