### PR TITLE
Travis: add compilation check 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
     - stage: build
       script:
         - yarn run eslint
+        - yarn compilex64
 
     - stage: build docker image
       install: true


### PR DESCRIPTION
Adds a check for binary compilation in the initial build stage on Travis. Adresses [this](https://github.com/dungeon-revealer/dungeon-revealer/pull/254#issuecomment-605513930).