### PR TITLE
Github Actions for CI and Binary Deployment

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,141 @@
+name: Build Binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  job_build_x64:
+    name: ${{ matrix.os }} Binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Compile x64 binary
+        run: |
+            yarn install
+            yarn build
+            yarn pkg . --target host --out-path ./bin/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: binaries
+          path: bin/
+
+  job_build_arm:
+    name: ARM Linux Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build arm
+        run: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register
+            wget https://github.com/multiarch/qemu-user-static/releases/download/v4.1.1-1/qemu-arm-static.tar.gz -O /tmp/qemu-arm-static.tar.gz
+            tar zxvf /tmp/qemu-arm-static.tar.gz -C /tmp
+            docker build -t dr-armbuild -f Dockerfile-armbuild .
+            sudo docker run --rm -v /tmp/qemu-arm-static:/usr/bin/qemu-arm-static -v $(pwd)/bin/:/usr/src/app/bin/ dr-armbuild /bin/sh -c 'yarn install; yarn compilearm'
+            cp bin/arm/dungeon-revealer bin/dungeon-revealer-linux-armv7
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: binaries
+          path: bin/
+
+  job_upload:
+    name: Upload Release Assets
+    needs: [job_build_x64, job_build_arm]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Github Actions is weird about environment variables.
+      # Setting a variable in this way makes it available to all subsequent steps in the job.
+      # The only way to get the tag is to extract it from github-ref.
+      # For example, GITHUB_REF='refs/tags/v1.5'.
+      - name: Set environment
+        run: |
+          export TAG="${GITHUB_REF#'refs/tags/'}"
+          echo "::set-env name=GH_TAG::$TAG"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: binaries
+          path: bin/
+
+      - name: Prepare assets
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+            chmod +x bin/dungeon-revealer-linux bin/dungeon-revealer-macos bin/dungeon-revealer-linux-armv7
+            zip "dungeon-revealer-linux-$GH_TAG.zip" -j bin/dungeon-revealer-linux README.md
+            zip "dungeon-revealer-linux-armv7-$GH_TAG.zip" -j bin/dungeon-revealer-linux-armv7 README.md
+            zip "dungeon-revealer-macos-$GH_TAG.zip" -j bin/dungeon-revealer-macos README.md
+            zip "dungeon-revealer-win-$GH_TAG.zip" -j bin/dungeon-revealer-win.exe README.md
+
+      # We have to upload assets individually using upload-release-asset@v1
+      # There isn't a matrix for steps.
+      - name: Upload Linux Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./dungeon-revealer-linux-${{ env.GH_TAG }}.zip
+          asset_name: dungeon-revealer-linux-${{ env.GH_TAG }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload MacOS Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./dungeon-revealer-macos-${{ env.GH_TAG }}.zip
+          asset_name: dungeon-revealer-macos-${{ env.GH_TAG }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Windows Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./dungeon-revealer-win-${{ env.GH_TAG }}.zip
+          asset_name: dungeon-revealer-win-${{ env.GH_TAG }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Linux ARM Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./dungeon-revealer-linux-armv7-${{ env.GH_TAG }}.zip
+          asset_name: dungeon-revealer-linux-armv7-${{ env.GH_TAG }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,0 +1,39 @@
+name: Node.js CI
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: yarn install
+      - run: yarn build
+      - run: yarn eslint
+      - run: yarn test
+        env:
+          CI: true
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build image
+        uses: docker/build-push-action@v1
+        with:
+          repository: apclary/dungeon-revealer
+          push: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ stages:
   - build docker image
   - name: dockerhub dev deploy
     if: (branch = master) AND (NOT (type = pull_request))
-  - name: github deploy
-    if: tag IS present
   - name: dockerhub deploy
     if: tag IS present
 
@@ -38,38 +36,6 @@ jobs:
         - docker build -t $DOCKER_USERNAME/dungeon-revealer:dev .
         - docker images
         - docker push $DOCKER_USERNAME/dungeon-revealer
-
-    - stage: github deploy
-      install:
-        - yarn install
-        - sudo docker run --rm --privileged multiarch/qemu-user-static:register
-        - wget https://github.com/multiarch/qemu-user-static/releases/download/v4.1.1-1/qemu-arm-static.tar.gz -O /tmp/qemu-arm-static.tar.gz
-        - tar zxvf /tmp/qemu-arm-static.tar.gz -C /tmp
-        - docker build -t dr-armbuild -f Dockerfile-armbuild .
-      script:
-        - echo "Deploying $TRAVIS_TAG to GitHub releases ..."
-        - echo "Building x64 binaries..."
-        - yarn compilex64
-        - echo "Building armv7 binaries..."
-        - sudo docker run --rm -v /tmp/qemu-arm-static:/usr/bin/qemu-arm-static -v $(pwd)/bin/:/usr/src/app/bin/ dr-armbuild /bin/sh -c 'yarn install; yarn compilearm'
-        - cp bin/arm/dungeon-revealer bin/dungeon-revealer-linux-armv7
-        - chmod +x bin/dungeon-revealer-linux bin/dungeon-revealer-macos bin/dungeon-revealer-linux-armv7
-        - zip "dungeon-revealer-linux-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-linux README.md
-        - zip "dungeon-revealer-linux-armv7-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-linux-armv7 README.md
-        - zip "dungeon-revealer-macos-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-macos README.md
-        - zip "dungeon-revealer-win-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-win.exe README.md
-      deploy:
-        provider: releases
-        api_key: $GITHUB_OAUTH_TOKEN
-        file:
-          - "dungeon-revealer-linux-$TRAVIS_TAG.zip"
-          - "dungeon-revealer-linux-armv7-$TRAVIS_TAG.zip"
-          - "dungeon-revealer-macos-$TRAVIS_TAG.zip"
-          - "dungeon-revealer-win-$TRAVIS_TAG.zip"
-        skip_cleanup: true
-        draft: true
-        on:
-          tags: true
 
     - stage: dockerhub deploy
       install: true


### PR DESCRIPTION
This PR partially migrates our CI/CD from Travis to Github Actions.

Fixes #182, allows #254 to be merged.

Actions Features:

- **Checks.** Branch and Pull Request checks are performed for node.js versions `10.x` and `12.x`. 
- **Compilation.** x64 binaries are compiled in their native operating systems instead of using cross compilation on Linux. Compiling natively in Windows fixes #182. 
- **Deployment.** On a tagged branch, a draft release is created and has the packages automatically uploaded to it.

Travis is still used for branch checks and Dockerhub deployment. See #363 for the full migration to Actions.