### PR TITLE
Use docker caches to speed up multiarch builds

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -32,8 +32,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Build image
-        uses: docker/build-push-action@v1
-        with:
-          repository: dungeonrevealer/dungeon-revealer
-          push: false
+        run: |
+          DOCKER_BUILDKIT=1 docker build .

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -23,6 +23,7 @@ jobs:
           export PLATFORM=${{ matrix.platform }}
           echo "::set-env name=DOCKER_REPO::dungeonrevealer/dungeon-revealer"
           echo "::set-env name=PLATFORM_DASH::${PLATFORM////-}"
+          echo "::set-env name=BUILD_FAIL::true"
         # ${foo////-} replaces slashes with dashes
         # foo='linux/arm/v7'
         # ${foo////-} -> linux-arm-v7
@@ -40,23 +41,60 @@ jobs:
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Run Buildx
+      - name: Run Buildx cache from registry
+        continue-on-error: true
         run: |
           docker buildx build \
             --platform ${{ matrix.platform }} \
             --output "type=image,push=false" \
             --build-arg CACHE=cache \
             --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH .
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH . && echo "::set-env name=BUILD_FAIL::false"
+
+      - name: Run Buildx local build cache
+        if: env.BUILD_FAIL == 'true'
+        continue-on-error: true
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --output "type=image,push=false" \
+            --build-arg CACHE=cache \
+            --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') . && echo "::set-env name=BUILD_FAIL::false"
+
+      - name: Run Buildx no cache
+        if: env.BUILD_FAIL == 'true'
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --output "type=image,push=false" \
+            --build-arg CACHE=cache \
+            --no-cache \
+            --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') .
 
       - name: Cache to registry
+        continue-on-error: true
         run: |
           docker buildx build \
             --platform ${{ matrix.platform }} \
             --build-arg CACHE=cache \
             --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
             --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH \
-            --cache-to=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH,mode=max . || echo "Caching failed."
+            --cache-to=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH,mode=max .
+
+      - name: Cache to local
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --build-arg CACHE=cache \
+            --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH \
+            --cache-to=type=local,dest=docker-cache/${{ matrix.platform }},mode=max .
+
+      - name: Upload local cache to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-cache
+          path: docker-cache
 
 
   deploy:
@@ -83,6 +121,12 @@ jobs:
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Download local cache artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-cache
+          path: docker-cache
+
       - name: Run Buildx Dev
         if: startsWith(github.ref, 'refs/heads/') # Just the branches
         run: |
@@ -91,11 +135,11 @@ jobs:
             --output "type=image,push=true" \
             --build-arg CACHE=cache \
             --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-amd64 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-386 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v6 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v7 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm64 \
+            --cache-from=type=local,src=docker-cache/linux/amd64 \
+            --cache-from=type=local,src=docker-cache/linux/386 \
+            --cache-from=type=local,src=docker-cache/linux/arm/v6 \
+            --cache-from=type=local,src=docker-cache/linux/arm/v7 \
+            --cache-from=type=local,src=docker-cache/linux/arm64 \
             -t $DOCKER_REPO:dev .
 
       - name: Run Buildx Release
@@ -106,11 +150,11 @@ jobs:
             --output "type=image,push=true" \
             --build-arg CACHE=cache \
             --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-amd64 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-386 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v6 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v7 \
-            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm64 \
+            --cache-from=type=local,src=docker-cache/linux/amd64 \
+            --cache-from=type=local,src=docker-cache/linux/386 \
+            --cache-from=type=local,src=docker-cache/linux/arm/v6 \
+            --cache-from=type=local,src=docker-cache/linux/arm/v7 \
+            --cache-from=type=local,src=docker-cache/linux/arm64 \
             -t $DOCKER_REPO:release \
             -t $DOCKER_REPO:$GH_TAG \
             -t $DOCKER_REPO:stable \

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,6 +7,7 @@ on:
       - 'v*'
 
 jobs:
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -16,6 +17,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set environment
+        run: |
+          export PLATFORM=${{ matrix.platform }}
+          echo "::set-env name=DOCKER_REPO::dungeonrevealer/dungeon-revealer"
+          echo "::set-env name=PLATFORM_DASH::${PLATFORM////-}"
+        # ${foo////-} replaces slashes with dashes
+        # foo='linux/arm/v7'
+        # ${foo////-} -> linux-arm-v7
 
       - name: Set up Docker Buildx
         id: buildx
@@ -35,16 +45,22 @@ jobs:
           docker buildx build \
             --platform ${{ matrix.platform }} \
             --output "type=image,push=false" \
-            --cache-to=type=local,dest=docker-cache/${{ matrix.platform }} ./
+            --build-arg CACHE=cache \
+            --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH .
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: docker-cache
-          path: docker-cache
+      - name: Cache to registry
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --build-arg CACHE=cache \
+            --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH \
+            --cache-to=type=registry,ref=$DOCKER_REPO:build-cache-$PLATFORM_DASH,mode=max . || echo "Caching failed."
+
 
   deploy:
-    name: Deploy
+    name: Deploy Images
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -67,23 +83,20 @@ jobs:
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - uses: actions/download-artifact@v1
-        with:
-          name: docker-cache
-          path: docker-cache
-
       - name: Run Buildx Dev
         if: startsWith(github.ref, 'refs/heads/') # Just the branches
         run: |
           docker buildx build \
             --platform linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64 \
             --output "type=image,push=true" \
-            -t $DOCKER_REPO:dev \
-            --cache-from=type=local,src=docker-cache/linux/amd64 \
-            --cache-from=type=local,src=docker-cache/linux/386 \
-            --cache-from=type=local,src=docker-cache/linux/arm/v6 \
-            --cache-from=type=local,src=docker-cache/linux/arm/v7 \
-            --cache-from=type=local,src=docker-cache/linux/arm64 ./
+            --build-arg CACHE=cache \
+            --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-amd64 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-386 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v6 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v7 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm64 \
+            -t $DOCKER_REPO:dev .
 
       - name: Run Buildx Release
         if: startsWith(github.ref, 'refs/tags/') # Just the tags
@@ -91,12 +104,14 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64 \
             --output "type=image,push=true" \
+            --build-arg CACHE=cache \
+            --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-amd64 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-386 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v6 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm-v7 \
+            --cache-from=type=registry,ref=$DOCKER_REPO:build-cache-linux-arm64 \
             -t $DOCKER_REPO:release \
             -t $DOCKER_REPO:$GH_TAG \
             -t $DOCKER_REPO:stable \
-            -t $DOCKER_REPO:latest \
-            --cache-from=type=local,src=docker-cache/linux/amd64 \
-            --cache-from=type=local,src=docker-cache/linux/386 \
-            --cache-from=type=local,src=docker-cache/linux/arm/v6 \
-            --cache-from=type=local,src=docker-cache/linux/arm/v7 \
-            --cache-from=type=local,src=docker-cache/linux/arm64 ./
+            -t $DOCKER_REPO:latest .


### PR DESCRIPTION
This imports a build cache from the [docker registry](https://hub.docker.com/repository/registry-1.docker.io/maxb2/dungeon-revealer/tags?page=1) when building images for release. After the build, it tries to export a build cache for each platform to the registry. 

**TL;DR**: [no cache or update sqlite3 (1:08:29)](https://github.com/maxb2/dungeon-revealer/actions/runs/99304162), [update src only (36:16)](https://github.com/maxb2/dungeon-revealer/actions/runs/99355737), [update dependency (46:25)](https://github.com/maxb2/dungeon-revealer/actions/runs/99389898)

The build will try to cache from the registry first. If that fails, it will build from the local build cache and takeover at the step that the previous build failed. If that fails, the image will be built from scratch with no cache. This way a valid build will always be built.

I separated the cache export to its own step because the connection to the registry [fails intermittently](https://github.com/docker/buildx/issues/271). I also allowed the cache export to fail without cancelling the whole workflow. The caches have to be separated by platform because the manifest list for build caches doesn't work with multiple platforms.

The Dockerfile now has an [optional stage](https://github.com/docker/cli/issues/1134#issuecomment-406449342) dedicated to building sqlite3. Architectures other than amd64 must compile it from source which takes ~20 minutes for the arm platforms. Since the sqlite3 version will change much less frequently than the rest of the dependencies, the `sqlite3-builder` stage will be built only when the version changes. By default, the docker build will not use `sqlite3-builder`. You must set the build argument `CACHE=cache` to enable it. You can also set the version of sqlite3 installed with `SQLITE3_VERSION`. It is highly recommended to enable BuildKit when building. 

For example:
```
DOCKER_BUILDKIT=1 docker build .
```
or, to use the sqlite3 builder with the version taken from package.json:
```
DOCKER_BUILDKIT=1 docker build --build-arg CACHE=cache --build-arg SQLITE3_VERSION=$(cat package.json | jq -r '.dependencies.sqlite3') .
```