### PR TITLE
Actions wiki deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,7 @@ docker-cache
 arm-compile.Dockerfile
 Dockerfile
 .github/
+docs/
+wiki/
+.vscode
+*.md

--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -1,0 +1,37 @@
+name: Deploy wiki
+
+
+on:
+  push:
+    paths:
+      # Trigger only when wiki directory changes
+      - 'wiki/**'
+    branches:
+      # And only on master branch
+      - master
+
+jobs:
+  deploy-wiki:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        # Fetch merge commit and last commit from pull request
+        fetch-depth: 2
+
+    - name: Set environment
+      run: |
+        # Set the author name, author email, and message from the pull request
+        echo "::set-env name=ACTION_MAIL::$(git log -n 1 --skip=1 --pretty=format:%ae)"
+        echo "::set-env name=ACTION_NAME::$(git log -n 1 --skip=1 --pretty=format:%an)"
+        echo "::set-env name=WIKI_PUSH_MESSAGE::$(git log -n 1 --skip=1 --pretty=format:%s)"
+
+
+
+    - name: Push Wiki Changes
+      uses: docker://decathlon/wiki-page-creator-action:2.0.1
+      env:
+        GH_PAT: ${{ secrets.GH_PAT }}
+        MD_FOLDER: wiki/
+        OWNER: dungeon-revealer
+        REPO_NAME: dungeon-revealer

--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -15,16 +15,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with: 
+      with:
         # Fetch merge commit and last commit from pull request
         fetch-depth: 2
 
     - name: Set environment
       run: |
+        # Skip if HEAD is a merge commit
+        if [[ $(git log -n 1 --pretty=format:%s) == "Merge Pull Request"* ]]; then
+          echo "Skipping Merge commit"
+          CMD='git log -n 1 --skip=1'
+        else
+          echo "Using current commit"
+          CMD='git log -n 1'
+        fi
         # Set the author name, author email, and message from the pull request
-        echo "::set-env name=ACTION_MAIL::$(git log -n 1 --skip=1 --pretty=format:%ae)"
-        echo "::set-env name=ACTION_NAME::$(git log -n 1 --skip=1 --pretty=format:%an)"
-        echo "::set-env name=WIKI_PUSH_MESSAGE::$(git log -n 1 --skip=1 --pretty=format:%s)"
+        echo "::set-env name=ACTION_MAIL::$(eval $CMD --pretty=format:%ae)"
+        echo "::set-env name=ACTION_NAME::$(eval $CMD --pretty=format:%an)"
+        echo "::set-env name=WIKI_PUSH_MESSAGE::$(eval $CMD --pretty=format:%s)"
 
 
 

--- a/wiki/Community-Showcase.md
+++ b/wiki/Community-Showcase.md
@@ -1,0 +1,21 @@
+Here is a showcase of the interesting ways members of our community are using dungeon-revealer. If you want us to feature your project using dungeon-revealer, please contact us!
+
+## Tabletop TV
+[hinjodragonfly](https://github.com/hinjodragonfly) has created a case for a television that sits on the tabletop. There is a [Raspberry Pi](https://www.raspberrypi.org/) in the case running dungeon-revealer and presenting the player view on the screen. The DM page is accessed with a tablet. 
+
+
+<img src="https://user-images.githubusercontent.com/58919182/71115958-68e6e580-21d3-11ea-917d-d17a5e1d81c6.jpg" alt="" width="500"/>
+
+<img src="https://user-images.githubusercontent.com/58919182/71115957-68e6e580-21d3-11ea-853a-5f63be61bcda.jpg" alt="" width="500"/>
+
+<img src="https://user-images.githubusercontent.com/58919182/71115959-697f7c00-21d3-11ea-9999-364bb6e52129.jpg" alt="" width="600"/>
+
+
+## Tabletop Simulator Mod
+[azzco](https://github.com/azzco) has made a [Tabletop Simulator mod](https://steamcommunity.com/sharedfiles/filedetails/?id=2164161399) that projects the player view onto the table background. Players can also view the map through the in-game tablets.
+
+<img src="https://media.discordapp.net/attachments/730140662691004598/731867556939300884/screenshot.png" alt="" width="600"/>
+<img src="https://steamuserimages-a.akamaihd.net/ugc/1322320201362126177/A05DA92F40DEA1C213858EEE2C081407A189863D/" alt="" width="600"/>
+<img src="https://steamuserimages-a.akamaihd.net/ugc/1322320201362190974/9D87EEB77C5C1B39ADCB308502DBF99A30AB5802/" alt="" width="600"/>
+<img src="https://steamuserimages-a.akamaihd.net/ugc/1322320201362192721/D223ADD2BB0B6E5DCCAEBC7F1C12C8B9C098ACE4/" alt="" width="600"/>
+

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,8 @@
+The files for the wiki are kept in the [wiki](https://github.com/dungeon-revealer/dungeon-revealer/tree/master/wiki) folder of the [dungeon-revealer repository](https://github.com/dungeon-revealer/dungeon-revealer/).
+To edit the wiki, you can [fork the repository](https://github.com/dungeon-revealer/dungeon-revealer/fork), make changes, and then open a pull request.
+It's the same process as if you were making changes to the code.
+
+
+You can also do all of this on the github website itself.
+Simply navigate to the [wiki](https://github.com/dungeon-revealer/dungeon-revealer/tree/master/wiki) folder, open the file you wish to edit, and click on the edit button.
+Github will take care of the fork and pull request processes for you.

--- a/wiki/Dice-Macros.md
+++ b/wiki/Dice-Macros.md
@@ -1,0 +1,127 @@
+## Chat Message Macros
+
+### Simple Macro
+
+```hbs
+<ChatMacro message="Attack with Axe [1d20] makes [2d6] Damage">
+  Attack with Axe
+</ChatMacro>
+```
+
+You can embed dice rolls by using a dice notation formula surrounded by square brackets. Besides using them in macros, you can also simply type dice rolls into the chat.
+
+Examples of dice rolls:
+
+- `[1d20]`
+- `[3d6]`
+- `[(1d4 + 1) * 3 ]`
+- `[1d9000]`
+
+When toggeling from the editor mode back into the rendered note mode the above macro will be rendered as a clickable button with the text `Attack with Axe`.
+Click that button for sending the contents of the `message` attribute (`Attack with Axe [1d20] makes [2d6] Damage`) to the chat!
+
+### Template Macro
+
+For more complex templates it is encouraged to use a template. Templates can be declared once per note and re-used with different variables:
+
+```hbs
+<Template id="attackTemplate">
+  <Box>
+    <BoxRow>
+      <span style="color:red;font-weight:bold">Attack with {{weapon}}</span>
+    </BoxRow>
+    <BoxRow>
+      <BoxColumn>
+        Attack Roll
+      </BoxColumn>
+      <BoxColumn>
+        {{attackRollFormula}}
+      </BoxColumn>
+    </BoxRow>
+    <BoxRow>
+      <BoxColumn>
+        Damage
+      </BoxColumn>
+      <BoxColumn>
+        {{damageRollFormula}}
+      </BoxColumn>
+    </BoxRow>
+  </Box>
+</Template>
+
+<ChatMacro
+  templateId="attackTemplate"
+  var-weapon="Handaxe"
+  var-attackRollFormula="[1d20 + 5]"
+  var-damageRollFormula="[1d6 + 6]"
+>
+  Attack with Handaxe
+</ChatMacro>
+
+<ChatMacro
+  templateId="attackTemplate"
+  var-weapon="Axe"
+  var-attackRollFormula="[1d20 + 4]"
+  var-damageRollFormula="[1d4 + 4]"
+>
+  Attack with Dagger
+</ChatMacro>
+```
+
+A template can be declared by using the `Template` tag. Make sure to set a unique `id` attribute that can later be used for referencing the template.
+
+Inside the template you can use the following html tags:
+
+- div (Allowed attributes: `style`)
+- span (Allowed attributes: `style`)
+
+As well as the following custom components for structuring content:
+
+- Box (Box with grey border and rounded corners)
+- BoxRow (Horizontal row)
+- BoxColumn (horizontal row column)
+
+Variables can bes set by using the variable name surrounded by curly brackets `{{myVariable}}`.
+
+The template can be used by setting the `templateId` attribute to the Template `id`. In addition variable values can be passed by setting them as attributes on the `ChatMacro` and prefixing them with `var-`.
+
+E.g. the attribute for substituting the `myVariable` variable is `var-myVariable="My Custom Value"`.
+
+This allows easily defining triggers for multiple skill checks or weapon attacks.
+
+```hbs
+<Template id="skillCheck">
+  <div style="background-image:url('/api/images/04545c2f-6f7b-4fc6-a9d8-6d6580503031');background-position: 100% center;background-size:contain;background-repeat:no-repeat">
+    <Box>
+      <BoxRow>
+        <BoxColumn>
+        <div style="font-weight:bold;color:#B71C1C">{title}</div>
+        </BoxCoumn>
+
+      </BoxRow>
+      <BoxRow>
+        <BoxColumn>{{attribute1}}</BoxColumn>
+        <BoxColumn>[1d20]</BoxColumn>
+      </BoxRow>
+      <BoxRow>
+        <BoxColumn>{{attribute2}}</BoxColumn>
+        <BoxColumn>[1d20]</BoxColumn>
+      </BoxRow>
+      <BoxRow>
+        <BoxColumn>{{attribute3}}</BoxColumn>
+        <BoxColumn>[1d20]</BoxColumn>
+      </BoxRow>
+    </Box>
+  </div>
+</Template>
+
+<ChatMacro
+  templateId="skillCheck"
+  var-title="Swim Skill Check"
+  var-attribute1="Dexterity"
+  var-attribute2="Constitution"
+  var-attribute3="Strength"
+>
+ Schwimmen Probe
+</ChatMacro>
+```

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,28 @@
+The app is separated into two sections. One for the dungeon master and one for the players.
+
+## Dungeon Master
+
+To use dungeon-revealer, the game master and the players must be on the same local network (usually a wifi network). The game master will start the server (see [Installation](https://github.com/maxb2/dungeon-revealer/wiki/Install)), navigate to the server's URL (`your-ip:3000/dm`) in a web browser, and then enter a password if it is set. At this point, they will be prompted to upload an image file of the map to share with the other players. The other players will navigate to the server (`your-ip:3000`) using their own browsers (laptop, tablet, or phone) and will remain at the home page. The connection information is displayed in command prompt for convenience.
+
+To clear areas of the map, click and draw on the map. You can switch the brush mode by clicking the "Reveal" or "Shroud" button. Alternatively, you can select an area to clear or shroud by clicking the "Select Area" button. Whenever the game master clears some of the fog of war from the map and it is ready to share with the players, they will click "Send" and the revealed areas of the map will appear in the players' browsers. What appears as a shadow to the DM will appear as pure blackness to players, thus only revealing the cleared sections of the map to them. The "Mark" button will display a circle for a period of time to indicate a point of interest.
+
+To switch to a different map, click "Map Library", and then select one of the maps you have already uploaded and click "Load". The "LIVE" indicator in the lower right indicates if the map currently on the dungeon master page is being presented on the player page. The "Stop Sharing" button will blank the player page in preparation for a new map to be loaded.
+
+You can add a [token](https://github.com/maxb2/dungeon-revealer/wiki/Tokens) with the "Token" tool. Click anywhere on the map to place it. The token can be changed by opening the context menu trough right-clicking on a single token. You can alter its label, color and size.
+
+### Shortcuts
+
+| Key            | Functionality                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| `1`            | select move tool.                                                                             |
+| `2`            | select area tool.                                                                             |
+| `3`            | select brush tool.                                                                            |
+| `4`            | select mark tool.                                                                             |
+| `5`            | select token tool.                                                                            |
+| `Shift`        | toggle between hide/reveal.                                                                   |
+| `CMD/Ctrl + S` | push map to players.                                                                          |
+| Hold `Alt`     | use move tool while `Alt` key is pressed and return to previous mode after `Alt` is released. |
+
+## Players
+
+Navigate to the server using a web browser and wait at the home page. (The connection information is displayed in command prompt for convenience.) When the dungeon master is ready, they will push a map to your webpage. You will see either a black screen or a partially covered image. You can zoom in/out and pan the map. On a long click you will place a "point of interest" on the map that will show as a red circle.

--- a/wiki/Grid.md
+++ b/wiki/Grid.md
@@ -1,0 +1,24 @@
+A grid helps to align tokens added to the map. Any token added to a map with a grid will default to the grid size. 
+
+## Creating the grid
+
+Click on the `Add Grid` button at the bottom to open the grid configuration menu.
+
+![grid1](https://user-images.githubusercontent.com/9096667/87483214-cc65b400-c5f8-11ea-95db-4a6df6fedfed.png)
+
+
+Move the blue square so that it contains at least one square of your map. This square selects the area that you will zoom into to make your final selection. You can adjust the size of the blue square if needed. Click next and you will see a zoomed view of your map. 
+
+![grid2](https://user-images.githubusercontent.com/9096667/87483232-d8ea0c80-c5f8-11ea-8288-67747054049b.png)
+
+Select one square of your map and click next. Finally, you can fine tune the dimensions of your grid to fit the map. If you know the pixel width of one square in your original image you can input it to the `side length` box. Click finish when you are done. 
+
+![grid3](https://user-images.githubusercontent.com/9096667/87483234-dab3d000-c5f8-11ea-8766-e872ef5da058.png)
+
+## Grid Settings
+
+Click on `Grid Settings` at the bottom of the main page to adjust the visual style of the grid.
+
+![grid-settings](https://user-images.githubusercontent.com/9096667/87482916-139f7500-c5f8-11ea-8dea-aff020e23d7f.png)
+
+You can adjust the visibility of the grid for both you and the players. The sliders adjust the color and transparency of the grid.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,11 @@
+dungeon-revealer is a web app for tabletop gaming to allow the game master to reveal areas of the game map to players. Join the [discord server](https://discord.gg/dS5khqk).
+
+## What the DM Sees
+
+![alt text](https://user-images.githubusercontent.com/14338007/83942937-68312280-a7f8-11ea-9a63-8307f1c12d50.png "DM's View")
+
+You can protect the DM area by setting a password.
+
+## What the players see
+
+![alt text](https://user-images.githubusercontent.com/14338007/83942940-6e270380-a7f8-11ea-9eb5-ec440ea57c83.png "Player's view")

--- a/wiki/Hosting.md
+++ b/wiki/Hosting.md
@@ -1,0 +1,14 @@
+Under construction!
+
+## Self-Hosting
+
+### Local Network
+
+Local network connection is currently the default assumption of these docs.
+
+### Remote Access
+
+In order to allow players and even other DMs to remotely access to your installation, you need to enable additional outside services. The easiest two approaches to this are either using a Virtual Private Network (VPN), or a combination of Dynamic DNS (DDNS) and local port forwarding:
+
+* **VPN:** Many modern routers feature built-in VPN configuration. See your router's docs for more details.
+* **DDNS:** A number of [free and paid online DDNS services](https://www.google.com/search?q=dynamic+dns&oq=dynamic+dns) exist that can forward a custom hostname to your home internet network. Using port forwarding (see your router's docs) it's easy to then forward a remote port to the host port of your Dungeon Revealer installation.

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -1,0 +1,70 @@
+The easiest way to use dungeon-revealer is to download the app from the [releases](https://github.com/dungeon-revealer/dungeon-revealer/releases) page here on github. There is also a [docker image](https://hub.docker.com/r/dungeonrevealer/dungeon-revealer) that is kept up to date with the releases in this repository.
+
+Running from the command prompt will present connection information and some debugging.
+Optionally, you may set a password for the dungeon master and/or players by setting the environmental variables `DM_PASSWORD` and `PC_PASSWORD` when starting the app. e.g. for linux `PC_PASSWORD='password1' DM_PASSWORD='password2' ./dungeon-revealer-linux`
+Leaving a variable undefined will disable authentication and allow public access for that section of the map.
+
+
+### Windows
+
+Double click the app. A command prompt will open with useful information.
+Then go to `localhost:3000` in your browser and point your players to `<YOUR_IPADDRESS>:3000`.
+This information is also present in the command prompt window.
+
+### OSX
+
+Open the zip file and extract the files to your preferred location.
+
+Double click the app. A terminal will open with useful information.
+Then go to `localhost:3000` in your browser and point your players to `<YOUR_IPADDRESS>:3000`.
+This information is also present in the terminal window.
+
+
+### Linux
+
+Open the zip file and extract the files to your preferred location.
+
+Then you can run the app directly in the terminal.
+
+```bash
+./dungeon-revealer-linux
+```
+
+Then go to `localhost:3000` in your browser and point your players to `<YOUR_IPADDRESS>:3000`.
+This information is also present in the terminal window.
+
+
+
+### Docker
+
+We provide docker images for x64, x86, and arm architectures.
+An up to date version of docker is required to make sure the correct image architecture is pulled for your host machine.
+To create an instance, run the following:
+
+```bash
+docker pull dungeonrevealer/dungeon-revealer:latest
+docker run -e DM_PASSWORD=<password> -e PC_PASSWORD=<password> -p <PORT>:3000 -v <DATA_DIR>:/usr/src/app/data -d dungeonrevealer/dungeon-revealer:latest
+```
+
+- Replace `<password>` with your chosen passwords.
+- Replace `<PORT>` with your preferred port.
+- `<DATA_DIR>` is the directory on the host filesystem in which you want to store the maps and settings. `<DATA_DIR>` **must be an absolute path.** One way to achieve this in linux is to navigate to the directory you want in the terminal and then use `$PWD/data` as `<DATA_DIR>`.
+
+In your browser, go to `<YOUR_IPADDRESS>:<PORT>/dm`. If your players are on the local network, have them go to `<YOUR_IPADDRESS>:<PORT>`.
+
+Below is an example docker-compose.yml file.
+
+```YAML
+version: '3'
+services:
+  dungeon-revealer:
+    image: dungeonrevealer/dungeon-revealer:latest
+    container_name: dungeon-revealer
+    environment:
+      - DM_PASSWORD=<password>
+      - PC_PASSWORD=<password>
+    volumes:
+      - <DATA_DIR>:/usr/src/app/data
+    ports:
+      - <PORT>:3000
+```

--- a/wiki/Notes.md
+++ b/wiki/Notes.md
@@ -1,0 +1,45 @@
+Notes are documents that the user can put in dungeon-revealer. Click the `Notes` button at the bottom to view the notes library. You can view existing notes or create new ones from the library. 
+
+## Creating Notes
+
+Click the `Create New Note` button in the notes library to make a new note.
+
+![note-library](https://user-images.githubusercontent.com/9096667/87478741-e51d9c00-c5ef-11ea-867f-348e195b71d6.png)
+
+ Notes are written in the popular [markdown syntax](https://guides.github.com/features/mastering-markdown/). There are buttons that input the syntax for common tasks: **bold**, *italics*, lists, images, and links. You can also set the permissions of the note to admin, which is only visible to the DM, or public, which is visible to everyone.
+
+Notes can be used in many ways. You can save creature/player stats, room descriptions, or even system rules so you can quickly reference them. 
+
+## Searching Notes
+On the main page, click on the search icon in the top right corner. A search box will pop up and you can search for any term. Players can also search through any notes with public permissions.
+
+![search](https://user-images.githubusercontent.com/9096667/87480101-4181bb00-c5f2-11ea-95f1-34a13e3c75f2.png)
+
+Click on a note from the list to open a box with the full note. There are buttons at the top that let you quickly edit, change permissions, or share the note. Sharing the note sends the note to the chat.
+
+![note](https://user-images.githubusercontent.com/9096667/87480109-434b7e80-c5f2-11ea-9d78-0e51fadf2196.png)
+
+## Importing Notes
+
+As the admin it is possible to import markdown files into dungeon-revealer.
+You can either drag & drop a `.zip` archive containing markdown files or a single markdown file into the dungeon-master section for starting an import.
+
+The files must follow this format convention:
+
+```md
+---
+id: unique-id
+title: The title of the note
+is_entry_point: true
+---
+
+This is the text of the note. It can contain any type of markdown. Such as **bold text** or [links](http://google.de).
+```
+
+The markdown files **MUST** start with a header constrained by `---`.
+Each line represents a value:
+
+- **`id`**. A global unique id for all notes. When importing a lot files it is recommended to prefix them with something like `collection-1-` to avoid clashes with other notes.
+- **`title`**. The title of the note.
+- **`is_entry_point`**. Either `true` or `false` depending on whether the note should pop-up in the notes library as an entry point or not.
+

--- a/wiki/Tokens.md
+++ b/wiki/Tokens.md
@@ -1,0 +1,9 @@
+Tokens are shapes that can be added to the map representing things such as creatures, players, items, area effects, notes or anything else you can think of.
+
+Click on the token tool on the left and then click somewhere on the map that you want to place a token. The token size will default to the grid size if it is present. Right click on a token to edit it. From the token menu you can name the token, change its size and color, hide/show the token to players, and link a note.
+
+![token-menu](https://user-images.githubusercontent.com/9096667/87476985-f3b68400-c5ec-11ea-8165-21d0f2c150d1.png)
+
+Tokens visible to players can also be moved by them. Click the `Lock` button at the bottom of the token menu to lock it in place.
+
+Linking a note to a token can be useful for the DM. You can use it for creature/player stats, item descriptions, room notes, or anything else you can think of. Click the `Link` button to link a note to the token. You can choose an existing note or create a new one. See the [Notes](https://github.com/maxb2/dungeon-revealer/wiki/Notes) page for more details.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,11 @@
+## [Home](https://github.com/dungeon-revealer/dungeon-revealer/wiki)
+## Setting up 
+### [Install](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Install)
+### [Hosting](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Hosting)
+## Using the app
+### [Getting Started](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Getting-Started)
+### [Tokens](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Tokens)
+### [Notes](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Notes)
+### [Dice Macros](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Dice-Macros)
+## Other
+### [Community Showcase](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Community-Showcase)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,5 +1,5 @@
 ## [Home](https://github.com/dungeon-revealer/dungeon-revealer/wiki)
-## Setting up 
+## Setting up
 ### [Install](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Install)
 ### [Hosting](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Hosting)
 ## Using the app
@@ -9,3 +9,4 @@
 ### [Dice Macros](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Dice-Macros)
 ## Other
 ### [Community Showcase](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Community-Showcase)
+### [Contributing](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Contributing)


### PR DESCRIPTION
This adds the contents of the wiki to the repository and adds an action to deploy any changes to the `wiki/` directory.

~~Blocked by #594.~~

@n1ru4l, can you set a new secret `GH_PAT` with the token generated from [here](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)? It's for [Decathlon/wiki-page-creator-action](https://github.com/marketplace/actions/wiki-page-creator-action)