### PR TITLE
Actions: master branch prerelease and discord notification

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -208,3 +208,11 @@ jobs:
           asset_path: ./bin/dungeon-revealer-linux-arm64.zip
           asset_name: dungeon-revealer-linux-arm64-${{ env.GH_TAG }}.zip
           asset_content_type: application/zip
+
+      - name: Discord notification
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: "New binary build finished, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.repository.html_url }}actions/runs/${{ github.run_id }}>"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -216,4 +216,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
         uses: Ilshidur/action-discord@master
         with:
-          args: "New binary build finished, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.repository.html_url }}actions/runs/${{ github.run_id }}>"
+          args: "New binary build finished, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}>"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -114,6 +114,7 @@ jobs:
 
       - name: Set environment
         run: |
+          echo "::set-env name=COMMIT_SHORT::$(git rev-parse --short HEAD)"
           node ./scripts/set-git-tag-env.js
 
       - name: Download Artifacts
@@ -210,7 +211,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Discord notification
-        if: success()
+        if: success() && startsWith( github.ref, 'refs/heads')
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
         uses: Ilshidur/action-discord@master

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -214,6 +214,6 @@ jobs:
         if: success() && startsWith( github.ref, 'refs/heads')
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@759f6ea
         with:
           args: "New binary build finished, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}>"

--- a/.github/workflows/discord-master-updates.yml
+++ b/.github/workflows/discord-master-updates.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Discord master update
 
 on:
   push:

--- a/.github/workflows/discord-master-updates.yml
+++ b/.github/workflows/discord-master-updates.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@759f6ea
         with:
           args: "New commit pushed, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.head_commit.url }}>"

--- a/.github/workflows/discord-master-updates.yml
+++ b/.github/workflows/discord-master-updates.yml
@@ -1,0 +1,23 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: "Set environment: master"
+        run: |
+          echo "::set-env name=COMMIT_SHORT::$(git rev-parse --short HEAD)"
+
+      - name: Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: "New commit pushed, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.head_commit.url }}>"

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -15,7 +15,7 @@ jobs:
         if: ${{ ! github.event.release.prerelease }} # Only releases
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@759f6ea
         with:
           args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the release at ${{ github.event.release.html_url }}."
 
@@ -24,6 +24,6 @@ jobs:
         if: ${{ github.event.release.prerelease }} # Only prereleases
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@759f6ea
         with:
           args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the prerelease at ${{ github.event.release.html_url }}. Help us test before the release is finalized. Join the discussion in #feedback"

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -1,0 +1,27 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Discord notification
+        if: ${{ ! github.event.release.prerelease }} # Only releases
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the release at ${{ github.event.release.html_url }}."
+
+
+      - name: Discord notification
+        if: ${{ github.event.release.prerelease }} # Only prereleases
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the prerelease at ${{ github.event.release.html_url }}. Help us test before the release is finalized. Join the discussion in #feedback."

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -26,4 +26,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
         uses: Ilshidur/action-discord@master
         with:
-          args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the prerelease at ${{ github.event.release.html_url }}. Help us test before the release is finalized. Join the discussion in #feedback."
+          args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the prerelease at ${{ github.event.release.html_url }}. Help us test before the release is finalized. Join the discussion in #feedback"

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -1,3 +1,5 @@
+name: Discord release update
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
This creates a draft prerelease page for binary builds on master. A discord message is sent whenever a release is published.


**TODO**
- [ ] Set `DISCORD_WEBHOOK_RELEASES` and `DISCORD_WEBHOOK_UPDATES` in repository secrets. You can find this in the discord server settings. (@n1ru4l)
- [x] ~~Delete past prereleases and tags to declutter releases page.~~ Prereleases will be maintained manually.
- [x] Write more meaningful discord messages (suggestions welcome).
- [x] Create action to send master updates to #git-updates.