### PR TITLE
Actions: discord embed messages

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -212,10 +212,35 @@ jobs:
           asset_name: dungeon-revealer-linux-arm64-${{ env.GH_TAG }}.zip
           asset_content_type: application/zip
 
+      - name: "Set environment for discord"
+        if: success() && startsWith( github.ref, 'refs/heads')
+        run: |
+          # Template json to send as an embed
+          # jq replaces $var with `jq --arg var <value> "$TEMPLATE"`
+          TEMPLATE='[{"title": $title, "url": $url, "color": $color, "description": $desc}]'
+
+          # Grab the list of commits from event.json
+          COMMITS=$(cat $GITHUB_EVENT_PATH | jq -c '.commits')
+
+          # Iterate through each commit and create the formatted string:
+          # [`<commit_sha_short>`](<commit_url>) <commit_message>\n <other_commits>
+          DESC=''
+          for row in $(echo "${COMMITS}" | jq -r '.[] | @base64'); do
+              _jq() {
+               echo ${row} | base64 --decode | jq -r ${1}
+              }
+             DESC=$DESC$(printf "[%s](%s) %s" $'`'"$(_jq '.id' | cut -c -7)"$'`' "$(_jq '.url')" "$(_jq '.message')")$'\n'
+          done
+
+          # Check if description is longer than the character limit
+          if [ ${#DESC} -gt 2048 ]; then
+            DESC=$(echo $DESC | cut -c -2045)"..."
+          fi
+          echo "$DESC"
+          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "[${{ github.event.repository.name }}:${GITHUB_REF##*/}] binary build" --arg url "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}" --arg color "16750848" --arg desc "$DESC" "$TEMPLATE")"
+
       - name: Discord notification
         if: success() && startsWith( github.ref, 'refs/heads')
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
-        uses: Ilshidur/action-discord@759f6ea
-        with:
-          args: "New binary build finished, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}>"
+        uses: Ilshidur/action-discord@0.3.0

--- a/.github/workflows/discord-master-updates.yml
+++ b/.github/workflows/discord-master-updates.yml
@@ -11,13 +11,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: "Set environment: master"
+      - name: "Set environment for discord"
         run: |
-          echo "::set-env name=COMMIT_SHORT::$(git rev-parse --short HEAD)"
+          # Template json to send as an embed
+          # jq replaces $var with `jq --arg var <value> "$TEMPLATE"`
+          TEMPLATE='[{"title": $title, "url": $url, "color": $color, "description": $desc}]'
+
+          # Grab the list of commits from event.json
+          COMMITS=$(cat $GITHUB_EVENT_PATH | jq -c '.commits')
+
+          # Iterate through each commit and create the formatted string:
+          # [`<commit_sha_short>`](<commit_url>) <commit_message>\n <other_commits>
+          DESC=''
+          for row in $(echo "${COMMITS}" | jq -r '.[] | @base64'); do
+              _jq() {
+               echo ${row} | base64 --decode | jq -r ${1}
+              }
+             DESC=$DESC$(printf "[%s](%s) %s" $'`'"$(_jq '.id' | cut -c -7)"$'`' "$(_jq '.url')" "$(_jq '.message')")$'\n'
+          done
+
+          # Check if description is longer than the character limit
+          if [ ${#DESC} -gt 2048 ]; then
+            DESC=$(echo $DESC | cut -c -2045)"..."
+          fi
+          echo "$DESC"
+          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "[${{ github.event.repository.name }}:${GITHUB_REF##*/}] new commit" --arg url "${{ github.event.compare }}" --arg color "13260" --arg desc "$DESC" "$TEMPLATE")"
 
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
-        uses: Ilshidur/action-discord@759f6ea
-        with:
-          args: "New commit pushed, master@${{ env.COMMIT_SHORT }}: *${{ github.event.head_commit.message }}*\n <${{ github.event.head_commit.url }}>"
+        uses: Ilshidur/action-discord@0.3.0

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -11,19 +11,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Discord notification
-        if: ${{ ! github.event.release.prerelease }} # Only releases
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
-        uses: Ilshidur/action-discord@759f6ea
-        with:
-          args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the release at ${{ github.event.release.html_url }}."
+      - name: "Set environment: release"
+        if: ${{ ! github.event.release.prerelease }} # Only prereleases
+        run: |
+          # Template json to send as an embed
+          # jq replaces $var with `jq --arg var <value> "$TEMPLATE"`
+          TEMPLATE='[{"title": $title, "url": $url, "color": $color, "description": $desc}]'
 
 
-      - name: Discord notification
+          DESC="@everyone [${{ github.event.repository.name }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}) release has been deployed!"$'\n'
+          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "${{ github.event.release.name }} release" --arg url "${{ github.event.release.html_url }}" --arg color "26880" --arg desc "$DESC" "$TEMPLATE")"
+
+      - name: "Set environment: prerelease"
         if: ${{ github.event.release.prerelease }} # Only prereleases
+        run: |
+          # Template json to send as an embed
+          # jq replaces $var with `jq --arg var <value> "$TEMPLATE"`
+          TEMPLATE='[{"title": $title, "url": $url, "color": $color, "description": $desc}]'
+
+          # <#channel_id> is the mention syntax for channels
+          # <#730140681581887528> mentions #feedback
+          DESC="@everyone [${{ github.event.repository.name }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}) prerelease has been deployed! Help us test before the release is finalized. Join the discussion in <#730140681581887528>"$'\n'
+          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "${{ github.event.release.name }} prerelease" --arg url "${{ github.event.release.html_url }}" --arg color "10027212" --arg desc "$DESC" "$TEMPLATE")"
+
+      - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
-        uses: Ilshidur/action-discord@759f6ea
-        with:
-          args: "@everyone ${{ github.event.repository.name }}@${{ github.event.release.tag_name }} has been deployed! Check out the prerelease at ${{ github.event.release.html_url }}. Help us test before the release is finalized. Join the discussion in #feedback"
+        uses: Ilshidur/action-discord@0.3.0


### PR DESCRIPTION
This changes the automated discord messages to [embeds](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html). Closes #666 :smiling_imp: 

## Master commits 
The title links to a page that compares the previous master branch to the new one. The message body lists all the new commits with links.
![Screenshot from 2020-09-11 13-34-23](https://user-images.githubusercontent.com/9096667/92960672-a52e3600-f433-11ea-952f-06be616962bd.png)


## Releases
The title and the body link to the release page. The body of the release is quoted (I'm considering changing this to a code block). I haven't been able to get #feedback to link to the text channel in discord. It might not be possible yet.
![Screenshot from 2020-09-11 13-47-27](https://user-images.githubusercontent.com/9096667/92962034-e9223a80-f435-11ea-9306-c9420f17c575.png)


## Binary Builds
The title links to the build workflow where you can download the build artifacts. The description lists the included commits with links.

![Screenshot from 2020-09-11 13-58-56](https://user-images.githubusercontent.com/9096667/92962721-fc81d580-f436-11ea-940e-cab852a72282.png)



### TODO
- [x] master commits
- [x] binary builds
   - [ ] ~~put release notes in fields~~
- [x] tagged releases
- [x] finalize color schemes
