### PR TITLE
wiki: add BDaB podcast episode to Community Showcase

### DIFF
--- a/wiki/Community-Showcase.md
+++ b/wiki/Community-Showcase.md
@@ -1,7 +1,7 @@
 Here is a showcase of the interesting ways members of our community are using dungeon-revealer. If you want us to feature your project using dungeon-revealer, please contact us!
 
 ## Tabletop TV
-[hinjodragonfly](https://github.com/hinjodragonfly) has created a case for a television that sits on the tabletop. There is a [Raspberry Pi](https://www.raspberrypi.org/) in the case running dungeon-revealer and presenting the player view on the screen. The DM page is accessed with a tablet. 
+[hinjodragonfly](https://github.com/hinjodragonfly) has created a case for a television that sits on the tabletop. There is a [Raspberry Pi](https://www.raspberrypi.org/) in the case running dungeon-revealer and presenting the player view on the screen. The DM page is accessed with a tablet.
 
 
 <img src="https://user-images.githubusercontent.com/58919182/71115958-68e6e580-21d3-11ea-917d-d17a5e1d81c6.jpg" alt="" width="500"/>
@@ -19,3 +19,5 @@ Here is a showcase of the interesting ways members of our community are using du
 <img src="https://steamuserimages-a.akamaihd.net/ugc/1322320201362190974/9D87EEB77C5C1B39ADCB308502DBF99A30AB5802/" alt="" width="600"/>
 <img src="https://steamuserimages-a.akamaihd.net/ugc/1322320201362192721/D223ADD2BB0B6E5DCCAEBC7F1C12C8B9C098ACE4/" alt="" width="600"/>
 
+## Bikers Dice and Bars Podcast
+The [Bikers Dice and Bars podcast](https://breakfastpuppies.com/podcasts/bikersdicebars) by [nonplayer](https://github.com/nonplayer) released an [episode about virtual tabletops](https://breakfastpuppies.com/podcast-feeds/bdab-bonus-virtual-tabletops-w-alex-hakobian/). They compare various VTTs and feature dungeon-revealer in their "offline VTT" section.


### PR DESCRIPTION
Add a podcast that discusses dungeon-revealer to the Community Showcase. 

@nonplayer, let me know if this is okay and if I should add or change anything.