### PR TITLE
docs: set heroku button to target tag v1.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In your browser, go to `<YOUR_IPADDRESS>:<PORT>/dm`. If your players are on the 
 
 Heroku is a platform supporting one-click deployments and includes a free usage tier. Sign up for a free account then click the button below. Give your app a unique name, set any required passwords, and click `Deploy App` to start the build process.
 
-[![button](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/dungeon-revealer/dungeon-revealer)
+[![button](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/dungeon-revealer/dungeon-revealer/tree/v1.10.3)
 
 ### Using the app
 


### PR DESCRIPTION
This sets the Heroku Deploy button to target the v1.10.3 tag. Previously, it would deploy the master branch which can sometimes be broken, see #794. We would also have to update the link manually every time we make a new release.