### PR TITLE
fix: actions environment

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Set environment
         run: |
-          echo "::set-env name=COMMIT_SHORT::$(git rev-parse --short HEAD)"
+          echo "COMMIT_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           node ./scripts/set-git-tag-env.js
 
       - name: Download Artifacts
@@ -237,7 +237,7 @@ jobs:
             DESC=$(echo $DESC | cut -c -2045)"..."
           fi
           echo "$DESC"
-          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "[${{ github.event.repository.name }}:${GITHUB_REF##*/}] binary build" --arg url "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}" --arg color "16750848" --arg desc "$DESC" "$TEMPLATE")"
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "[${{ github.event.repository.name }}:${GITHUB_REF##*/}] binary build" --arg url "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}" --arg color "16750848" --arg desc "$DESC" "$TEMPLATE")" >> $GITHUB_ENV
 
       - name: Discord notification
         if: success() && startsWith( github.ref, 'refs/heads')

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Set environment
         run: |
           export PLATFORM=${{ matrix.platform }}
-          echo "::set-env name=PLATFORM_DASH::${PLATFORM////-}"
-          echo "::set-env name=BUILD_FAIL::true"
+          echo "PLATFORM_DASH=${PLATFORM////-}" >> $GITHUB_ENV
+          echo "BUILD_FAIL=true" >> $GITHUB_ENV
 
         # ${foo////-} replaces slashes with dashes
         # foo='linux/arm/v7'
@@ -77,7 +77,7 @@ jobs:
             --output "type=image,push=false" \
             --build-arg SKIP_BUILD="true" \
             --cache-from=type=registry,ref=${{ secrets.DOCKER_REPO }}:build-cache-$PLATFORM_DASH \
-            . && echo "::set-env name=BUILD_FAIL::false"
+            . && echo "BUILD_FAIL=false" >> $GITHUB_ENV
 
       - name: Run Buildx local build cache
         if: env.BUILD_FAIL == 'true'
@@ -87,7 +87,7 @@ jobs:
             --platform ${{ matrix.platform }} \
             --output "type=image,push=false" \
             --build-arg SKIP_BUILD="true" \
-            . && echo "::set-env name=BUILD_FAIL::false"
+            . && echo "BUILD_FAIL=false" >> $GITHUB_ENV
 
       - name: Run Buildx no cache
         if: env.BUILD_FAIL == 'true'
@@ -137,7 +137,7 @@ jobs:
       - name: Set environment
         run: |
           export TAG="${GITHUB_REF#'refs/tags/'}"
-          echo "::set-env name=GH_TAG::$TAG"
+          echo "GH_TAG=$TAG" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -30,9 +30,9 @@ jobs:
           CMD='git log -n 1'
         fi
         # Set the author name, author email, and message from the pull request
-        echo "::set-env name=ACTION_MAIL::$(eval $CMD --pretty=format:%ae)"
-        echo "::set-env name=ACTION_NAME::$(eval $CMD --pretty=format:%an)"
-        echo "::set-env name=WIKI_PUSH_MESSAGE::$(eval $CMD --pretty=format:%s)"
+        echo "ACTION_MAIL=$(eval $CMD --pretty=format:%ae)" >> $GITHUB_ENV
+        echo "ACTION_NAME=$(eval $CMD --pretty=format:%an)" >> $GITHUB_ENV
+        echo "WIKI_PUSH_MESSAGE=$(eval $CMD --pretty=format:%s)" >> $GITHUB_ENV
 
 
 

--- a/.github/workflows/discord-master-updates.yml
+++ b/.github/workflows/discord-master-updates.yml
@@ -35,7 +35,7 @@ jobs:
             DESC=$(echo $DESC | cut -c -2045)"..."
           fi
           echo "$DESC"
-          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "[${{ github.event.repository.name }}:${GITHUB_REF##*/}] new commit" --arg url "${{ github.event.compare }}" --arg color "13260" --arg desc "$DESC" "$TEMPLATE")"
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "[${{ github.event.repository.name }}:${GITHUB_REF##*/}] new commit" --arg url "${{ github.event.compare }}" --arg color "13260" --arg desc "$DESC" "$TEMPLATE")" >> $GITHUB_ENV
 
       - name: Discord notification
         env:

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -20,7 +20,7 @@ jobs:
 
 
           DESC="@everyone [${{ github.event.repository.name }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}) release has been deployed!"$'\n'
-          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "${{ github.event.release.name }} release" --arg url "${{ github.event.release.html_url }}" --arg color "26880" --arg desc "$DESC" "$TEMPLATE")"
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "${{ github.event.release.name }} release" --arg url "${{ github.event.release.html_url }}" --arg color "26880" --arg desc "$DESC" "$TEMPLATE")" >> $GITHUB_ENV
 
       - name: "Set environment: prerelease"
         if: ${{ github.event.release.prerelease }} # Only prereleases
@@ -32,7 +32,7 @@ jobs:
           # <#channel_id> is the mention syntax for channels
           # <#730140681581887528> mentions #feedback
           DESC="@everyone [${{ github.event.repository.name }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}) prerelease has been deployed! Help us test before the release is finalized. Join the discussion in <#730140681581887528>"$'\n'
-          echo "::set-env name=DISCORD_EMBEDS::$(jq -nc --arg title "${{ github.event.release.name }} prerelease" --arg url "${{ github.event.release.html_url }}" --arg color "10027212" --arg desc "$DESC" "$TEMPLATE")"
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "${{ github.event.release.name }} prerelease" --arg url "${{ github.event.release.html_url }}" --arg color "10027212" --arg desc "$DESC" "$TEMPLATE")" >> $GITHUB_ENV
 
       - name: Discord notification
         env:

--- a/scripts/set-git-tag-env.js
+++ b/scripts/set-git-tag-env.js
@@ -6,4 +6,4 @@
 // For example, GITHUB_REF='refs/tags/v1.5'.
 const tag = process.env.GITHUB_REF.replace("refs/tags/", "");
 console.log("Setting GitHub Environment Variable.");
-console.log(`::set-env name=GH_TAG::${tag}`);
+console.log(`echo GH_TAG=${tag} >> $GITHUB_ENV`);


### PR DESCRIPTION
The `set-env` command has been [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) in Actions. This updates the actions workflows to use the new [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).