### PR TITLE
actions: remove extraneous options from docker/setup-buildx-action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -156,9 +156,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          buildx-version: latest
-          qemu-version: latest
+
 
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin


### PR DESCRIPTION
From a Build Docker run:
```
Unexpected input(s) 'buildx-version', 'qemu-version', valid inputs are ['version', 'driver', 'driver-opts', 'buildkitd-flags', 'install', 'use', 'endpoint']
```