### PR TITLE
fix(actions): set GH_TAG env

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -115,11 +115,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
       - name: Set environment
         run: |
           echo "COMMIT_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Set environment
         run: |
           echo "COMMIT_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          node ./scripts/set-git-tag-env.js
+          echo "GH_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Download Artifacts
         uses: actions/download-artifact@v2

--- a/scripts/set-git-tag-env.js
+++ b/scripts/set-git-tag-env.js
@@ -1,9 +1,0 @@
-"use strict";
-
-// Github Actions is weird about environment variables.
-// Setting a variable in this way makes it available to all subsequent steps in the job.
-// The only way to get the tag is to extract it from github-ref.
-// For example, GITHUB_REF='refs/tags/v1.5'.
-const tag = process.env.GITHUB_REF.replace("refs/tags/", "");
-console.log("Setting GitHub Environment Variable.");
-console.log(`echo GH_TAG=${tag} >> $GITHUB_ENV`);


### PR DESCRIPTION
The `set-git-tag-env.js` script didn't work with the new environment in Actions (#886). This replaces that script with a bash pattern substitution.