### PR TITLE
Actions remove warnings

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -9,10 +9,17 @@ on:
 jobs:
   build_x64_native:
     name: ${{ matrix.os }} Binaries
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
+        include:
+          - os: ubuntu
+            runner: ubuntu-20.04
+          - os: macos
+            runner: macos-latest
+          - os: windows
+            runner: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -52,7 +59,7 @@ jobs:
 
   build_arm:
     name: ${{ matrix.arch }} Binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         platform: [linux/arm/v7, linux/arm64/v8]
@@ -110,7 +117,7 @@ jobs:
   job_upload:
     name: Upload Release Assets
     needs: [build_x64_native, build_arm]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -35,5 +35,4 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v2
         with:
-          repository: ${{ secrets.DOCKER_REPO }}
           push: false

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [12.x, 14.x]
@@ -28,7 +28,7 @@ jobs:
           CI: true
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-app:
     name: Build app
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   build:
     name: Build
     needs: build-app
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         platform: [linux/amd64, linux/arm/v7, linux/arm64]
@@ -129,7 +129,7 @@ jobs:
   deploy:
     name: Deploy Images
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   deploy-wiki:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/discord-master-updates.yml
+++ b/.github/workflows/discord-master-updates.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This addresses all of the recent warnings in the Actions runs:
- Pin runner os to `ubuntu-20.04`
- Remove deprecated `repository` option from `docker/build-push-action@v2`

[Test runs](https://github.com/maxb2/dungeon-revealer/runs/1466409398) on my fork.