### PR TITLE
added link styling in notes

### DIFF
--- a/src/dm-area/components/html-container.tsx
+++ b/src/dm-area/components/html-container.tsx
@@ -171,6 +171,11 @@ const HtmlContainerStyled = styled.div`
     max-width: 100%;
   }
 
+  a {
+    color: blue;
+    text-decoration: underline;
+  }
+
   p {
     margin-top: 0;
     margin-bottom: 4px;


### PR DESCRIPTION
Saw the issue about the link text in the notes not looking like links. There were two ways to fix it, but I chose to just edit the css.