### PR TITLE
Actions release

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -149,6 +149,11 @@ jobs:
           do
             (cd "$idir"; rm dungeon-revealer || true; zip -r "../${idir%/}.zip" .);
           done
+          mv bin/dungeon-revealer-ubuntu.zip bin/dungeon-revealer-linux-${{ env.GH_TAG }}.zip
+          mv bin/dungeon-revealer-macos.zip bin/dungeon-revealer-macos-${{ env.GH_TAG }}.zip
+          mv bin/dungeon-revealer-windows.zip bin/dungeon-revealer-windows-${{ env.GH_TAG }}.zip
+          mv bin/dungeon-revealer-linux-armv7.zip bin/dungeon-revealer-linux-armv7-${{ env.GH_TAG }}.zip
+          mv bin/dungeon-revealer-linux-arm64.zip bin/dungeon-revealer-linux-arm64-${{ env.GH_TAG }}.zip
 
       - name: Upload Zip Artifacts
         uses: actions/upload-artifact@v2
@@ -156,74 +161,17 @@ jobs:
           name: dungeon-revealer-binaries-${{ github.sha }}
           path: "bin/*.zip"
 
-      - name: Create Release
-        if: startsWith( github.ref, 'refs/tags/' ) # Run on tags only.
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           draft: true
-          prerelease: false
+          files: |
+            mv bin/*.zip
 
-      # We have to upload assets individually using upload-release-asset@v1
-      # There isn't a matrix for steps.
-      - name: Upload Linux Release
-        if: startsWith( github.ref, 'refs/tags/' ) # Run on tags only.
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./bin/dungeon-revealer-ubuntu.zip
-          asset_name: dungeon-revealer-linux-${{ env.GH_TAG }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload MacOS Release
-        if: startsWith( github.ref, 'refs/tags/' ) # Run on tags only.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./bin/dungeon-revealer-macos.zip
-          asset_name: dungeon-revealer-macos-${{ env.GH_TAG }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload Windows Release
-        if: startsWith( github.ref, 'refs/tags/' ) # Run on tags only.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./bin/dungeon-revealer-windows.zip
-          asset_name: dungeon-revealer-windows-${{ env.GH_TAG }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload Linux armv7 Release
-        if: startsWith( github.ref, 'refs/tags/' ) # Run on tags only.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./bin/dungeon-revealer-linux-armv7.zip
-          asset_name: dungeon-revealer-linux-armv7-${{ env.GH_TAG }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload Linux arm64 Release
-        if: startsWith( github.ref, 'refs/tags/' ) # Run on tags only.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./bin/dungeon-revealer-linux-arm64.zip
-          asset_name: dungeon-revealer-linux-arm64-${{ env.GH_TAG }}.zip
-          asset_content_type: application/zip
 
       - name: "Set environment for discord"
         if: success() && startsWith( github.ref, 'refs/heads')

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -149,11 +149,11 @@ jobs:
           do
             (cd "$idir"; rm dungeon-revealer || true; zip -r "../${idir%/}.zip" .);
           done
-          mv bin/dungeon-revealer-ubuntu.zip bin/dungeon-revealer-linux-${{ env.GH_TAG }}.zip
-          mv bin/dungeon-revealer-macos.zip bin/dungeon-revealer-macos-${{ env.GH_TAG }}.zip
-          mv bin/dungeon-revealer-windows.zip bin/dungeon-revealer-windows-${{ env.GH_TAG }}.zip
-          mv bin/dungeon-revealer-linux-armv7.zip bin/dungeon-revealer-linux-armv7-${{ env.GH_TAG }}.zip
-          mv bin/dungeon-revealer-linux-arm64.zip bin/dungeon-revealer-linux-arm64-${{ env.GH_TAG }}.zip
+          mv dungeon-revealer-ubuntu.zip dungeon-revealer-linux-${{ env.GH_TAG }}.zip
+          mv dungeon-revealer-macos.zip dungeon-revealer-macos-${{ env.GH_TAG }}.zip
+          mv dungeon-revealer-windows.zip dungeon-revealer-windows-${{ env.GH_TAG }}.zip
+          mv dungeon-revealer-linux-armv7.zip dungeon-revealer-linux-armv7-${{ env.GH_TAG }}.zip
+          mv dungeon-revealer-linux-arm64.zip dungeon-revealer-linux-arm64-${{ env.GH_TAG }}.zip
 
       - name: Upload Zip Artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This simplifies the creation of the Github Release and uploading of the assets using [softprops/action-gh-release](https://github.com/softprops/action-gh-release). The previous action, [actions/upload-release-asset](https://github.com/actions/upload-release-asset), has been deprecated.