### PR TITLE
Docker alpine downgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ FROM dependency-builder as production-dependency-builder
 RUN npm prune --production
 
 
-FROM node:16-alpine as final
+FROM node:16-alpine3.12 as final
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as base
+FROM node:16-alpine3.12 as base
 
 # add build tools for other architectures
 # subsequent builds should cache this layer


### PR DESCRIPTION
Alpine3.13 uses a 64-bit library in musl. This can't be run on 32-bit hardware (raspi).

Fixes #1394 