### PR TITLE
Docker use node:16-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM node:16-slim as base
-
-FROM base as dependency-builder
+FROM node:16 as dependency-builder
 
 WORKDIR /usr/src/build
 
@@ -23,7 +21,7 @@ FROM dependency-builder as production-dependency-builder
 RUN npm prune --production
 
 
-FROM base as final
+FROM node:16-slim as final
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM node:16-alpine3.12 as base
-
-# add build tools for other architectures
-# subsequent builds should cache this layer
-RUN apk add make g++ python3
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
+FROM node:16-slim as base
 
 FROM base as dependency-builder
 
@@ -29,7 +23,7 @@ FROM dependency-builder as production-dependency-builder
 RUN npm prune --production
 
 
-FROM node:16-alpine3.12 as final
+FROM base as final
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
This changes the docker base image to node:16-slim which is based on Debian Buster. The final image size does increase by about 40%.

Related #1397, #1394