### PR TITLE
feat: add version to log output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-#.git
 node_modules
 npm-debug.log
 data/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.git
+#.git
 node_modules
 npm-debug.log
 data/

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        os: [ubuntu, windows, macos]
-        node-version: [14.x, 16.x]
+        - os: [ubuntu, windows, macos]
+        - node-version: [14.x, 16.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        - os: [ubuntu, windows, macos]
-        - node-version: [14.x, 16.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [14.x, 16.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
+        os: [ubuntu, windows, macos]
         node-version: [14.x, 16.x]
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ server-build
 __generated__
 dist
 public/monaco-editor
+server/version.ts
 
 # Runtime Data/ Persisted Data #
 ################################

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "app.js",
   "bin": "bin/dungeon-revealer",
   "scripts": {
-    "prebuild": "cross-env node scripts/prebuild.js",
+    "prebuild": "node scripts/prebuild.js",
     "build:frontend": "node scripts/copy-monaco-editor-files.js && npm run relay-compiler && vite build --base=./",
     "build:backend": "tsc --project server/tsconfig.json",
     "build": "npm run build:frontend && npm run build:backend",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "app.js",
   "bin": "bin/dungeon-revealer",
   "scripts": {
+    "prebuild": "node -p \"'export const DR_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > server/version.ts",
     "build:frontend": "node scripts/copy-monaco-editor-files.js && npm run relay-compiler && vite build --base=./",
     "build:backend": "tsc --project server/tsconfig.json",
     "build": "npm run build:frontend && npm run build:backend",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "app.js",
   "bin": "bin/dungeon-revealer",
   "scripts": {
-    "prebuild": "node -p \"'export const DR_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > server/version.ts",
+    "prebuild": "cross-env node scripts/prebuild.js",
     "build:frontend": "node scripts/copy-monaco-editor-files.js && npm run relay-compiler && vite build --base=./",
     "build:backend": "tsc --project server/tsconfig.json",
     "build": "npm run build:frontend && npm run build:backend",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,43 +1,45 @@
 "use strict";
-const fse = require('fs-extra');
-const pkg = require('../package.json');
-const { spawnSync } = require('child_process');
+const fse = require("fs-extra");
+const pkg = require("../package.json");
+const { spawnSync } = require("child_process");
 
 const version = {
-    'appVersion': pkg.version,
-    'status': 'unknown',
-    'tag': '',
-    'commit': '',
-    'commitsAhead': 0,
-    'obj': ''
+  appVersion: pkg.version,
+  status: "unknown",
+  tag: "",
+  commit: "",
+  commitsAhead: 0,
+  obj: "",
 };
 
 const exec = spawnSync("git", ["describe", "--tags"]);
 
 if (exec.status !== 0) {
-    version.status = 'unknown';
+  version.status = "unknown";
 } else {
-    const gitDesc = exec.stdout.toString().replace('\n', '');
-    const gdArray = gitDesc.split('-');
-    version.tag = gdArray[0];
-    if (gitDesc.slice(1) === version.appversion) {
-        version.status = 'release';
-    } else {
-        version.status = 'development';
-        version.commit = spawnSync("git", ["rev-parse", "--short", "HEAD"]).stdout.toString().replace('\n', '');
-        version.commitsAhead = gdArray[1];
-        version.obj = gdArray[2];
-    }
+  const gitDesc = exec.stdout.toString().replace("\n", "");
+  const gdArray = gitDesc.split("-");
+  version.tag = gdArray[0];
+  if (gitDesc.slice(1) === version.appversion) {
+    version.status = "release";
+  } else {
+    version.status = "development";
+    version.commit = spawnSync("git", ["rev-parse", "--short", "HEAD"])
+      .stdout.toString()
+      .replace("\n", "");
+    version.commitsAhead = gdArray[1];
+    version.obj = gdArray[2];
+  }
 }
 
-const entries = Object.entries(version)
-let tsOut = '';
+const entries = Object.entries(version);
+let tsOut = "";
 for (const entry of entries) {
-    tsOut += `export const ${entry[0]} = '${entry[1]}';\n`
+  tsOut += `export const ${entry[0]} = '${entry[1]}';\n`;
 }
 
-fse.outputFileSync('server/version.ts', tsOut, (err) => {
-    if (err) {
-        console.log(err);
-    }
-})
+fse.outputFileSync("server/version.ts", tsOut, (err) => {
+  if (err) {
+    console.log(err);
+  }
+});

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,0 +1,62 @@
+const fse = require('fs-extra')
+const { spawnSync } = require('child_process');
+var exec = spawnSync("git",
+    ["describe", "--tags"],
+);
+
+let myenv = {
+    'appversion': '',
+    'status': 'unknown',
+    'tag': '',
+    'commit': '',
+    'commits_ahead': 0,
+    'obj': ''
+};
+
+const package = require('../package.json');
+
+myenv.appversion = package.version;
+
+
+if (exec.status != 0) {
+    env.status = 'unknown'
+} else {
+    let git_desc = exec.stdout.toString().replace('\n', '');
+    let gd_array = git_desc.split('-')
+    myenv.tag = gd_array[0];
+    if (git_desc == myenv.appversion) {
+        myenv.status = 'release';
+    } else {
+        myenv.status = 'development';
+        myenv.commit = spawnSync("git",
+            ["rev-parse", "--short", "HEAD"],
+        ).stdout.toString().replace('\n', '');
+        myenv.commits_ahead = gd_array[1];
+        myenv.obj = gd_array[2]
+    }
+}
+
+// console.log(myenv)
+
+outstr = '';
+
+let entries = Object.entries(myenv)
+
+
+
+for (const x of entries) {
+    outstr += `export const ${x[0]} = '${x[1]}';\n`
+}
+
+// console.log(outstr)
+
+
+fse.outputFileSync('server/version.ts', outstr, (err) => {
+    if (err)
+        console.log(err);
+    else {
+        console.log("File written successfully\n");
+        console.log("The written has the following contents:");
+        console.log(fs.readFileSync("version.ts", "utf8"));
+    }
+})

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,41 +1,42 @@
-const fse = require('fs-extra')
-const package = require('../package.json');
+"use strict";
+const fse = require('fs-extra');
+const pkg = require('../package.json');
 const { spawnSync } = require('child_process');
 
-let version = {
-    'appversion': package.version,
+const version = {
+    'appVersion': pkg.version,
     'status': 'unknown',
     'tag': '',
     'commit': '',
-    'commits_ahead': 0,
+    'commitsAhead': 0,
     'obj': ''
 };
 
-var exec = spawnSync("git", ["describe", "--tags"]);
+const exec = spawnSync("git", ["describe", "--tags"]);
 
-if (exec.status != 0) {
+if (exec.status !== 0) {
     version.status = 'unknown';
 } else {
-    let git_desc = exec.stdout.toString().replace('\n', '');
-    let gd_array = git_desc.split('-');
-    version.tag = gd_array[0];
-    if (git_desc.slice(1) == version.appversion) {
+    const gitDesc = exec.stdout.toString().replace('\n', '');
+    const gdArray = gitDesc.split('-');
+    version.tag = gdArray[0];
+    if (gitDesc.slice(1) === version.appversion) {
         version.status = 'release';
     } else {
         version.status = 'development';
         version.commit = spawnSync("git", ["rev-parse", "--short", "HEAD"]).stdout.toString().replace('\n', '');
-        version.commits_ahead = gd_array[1];
-        version.obj = gd_array[2];
+        version.commitsAhead = gdArray[1];
+        version.obj = gdArray[2];
     }
 }
 
-let entries = Object.entries(version)
-ts_out = '';
+const entries = Object.entries(version)
+let tsOut = '';
 for (const entry of entries) {
-    ts_out += `export const ${entry[0]} = '${entry[1]}';\n`
+    tsOut += `export const ${entry[0]} = '${entry[1]}';\n`
 }
 
-fse.outputFileSync('server/version.ts', ts_out, (err) => {
+fse.outputFileSync('server/version.ts', tsOut, (err) => {
     if (err) {
         console.log(err);
     }

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { getDefaultDataDirectory } from "./util";
+import { DR_VERSION } from './version';
 
 export const getEnv = (env: NodeJS.ProcessEnv) => {
   const PUBLIC_PATH = path.resolve(__dirname, "..", "build");
@@ -18,5 +19,6 @@ export const getEnv = (env: NodeJS.ProcessEnv) => {
     HOST,
     PC_PASSWORD,
     DM_PASSWORD,
+    DR_VERSION,
   };
 };

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { getDefaultDataDirectory } from "./util";
-import { DR_VERSION } from './version';
+import * as VERSION from "./version";
 
 export const getEnv = (env: NodeJS.ProcessEnv) => {
   const PUBLIC_PATH = path.resolve(__dirname, "..", "build");
@@ -19,6 +19,6 @@ export const getEnv = (env: NodeJS.ProcessEnv) => {
     HOST,
     PC_PASSWORD,
     DM_PASSWORD,
-    DR_VERSION,
+    VERSION
   };
 };

--- a/server/index.js
+++ b/server/index.js
@@ -26,7 +26,7 @@ const getListeningAddresses = () => {
 
 bootstrapServer(env).then(({ httpServer }) => {
   const server = httpServer.listen(env.PORT, env.HOST, () => {
-    console.log(`\nStarting dungeon-revealer.
+    console.log(`\nStarting dungeon-revealer@${env.DR_VERSION} 
 
 Configuration:
 - HOST: ${env.HOST} 

--- a/server/index.js
+++ b/server/index.js
@@ -27,16 +27,16 @@ const getListeningAddresses = () => {
 bootstrapServer(env).then(({ httpServer }) => {
   const server = httpServer.listen(env.PORT, env.HOST, () => {
 
-    let version_string;
-    if (env.VERSION.status == 'release') {
-      version_string = env.VERSION.appversion;
-    } else if (env.VERSION.status == 'development') {
-      version_string = `${env.VERSION.commit}\nThis development version is ${env.VERSION.commits_ahead} commits ahead of ${env.VERSION.tag}!\n`;
+    let versionString;
+    if (env.VERSION.status === 'release') {
+      versionString = env.VERSION.appversion;
+    } else if (env.VERSION.status === 'development') {
+      versionString = `${env.VERSION.commit}\nThis development version is ${env.VERSION.commits_ahead} commits ahead of ${env.VERSION.tag}!\n`;
     } else {
-      version_string = `${env.VERSION.appversion}\nI couldn't verify the git commit of this version, but I think it's based on ${env.VERSION.appversion}.\n`;
+      versionString = `${env.VERSION.appversion}\nI couldn't verify the git commit of this version, but I think it's based on ${env.VERSION.appversion}.\n`;
     }
 
-    console.log(`\nStarting dungeon-revealer@${version_string} 
+    console.log(`\nStarting dungeon-revealer@${versionString} 
 
 Configuration:
 - HOST: ${env.HOST} 

--- a/server/index.js
+++ b/server/index.js
@@ -9,8 +9,6 @@ const { getEnv } = require("./env");
 
 const env = getEnv(process.env);
 
-console.log(env.VERSION)
-
 const getPublicInterfaces = () => {
   const ifaces = os.networkInterfaces();
   return flatMap(Object.values(ifaces))
@@ -34,10 +32,8 @@ bootstrapServer(env).then(({ httpServer }) => {
       version_string = env.VERSION.appversion;
     } else if (env.VERSION.status == 'development') {
       version_string = `${env.VERSION.commit}\nThis development version is ${env.VERSION.commits_ahead} commits ahead of ${env.VERSION.tag}!\n`;
-    } else if (env.VERSION.status == 'unknown') {
-      version_string = `${env.VERSION.appversion}\nI couldn't verify the git commit of this version! I think it is based on ${env.VERSION.appversion}.\n`;
     } else {
-      console.log(`version: ${env.VERSION}`)
+      version_string = `${env.VERSION.appversion}\nI couldn't verify the git commit of this version, but I think it's based on ${env.VERSION.appversion}.\n`;
     }
 
     console.log(`\nStarting dungeon-revealer@${version_string} 

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,8 @@ const { getEnv } = require("./env");
 
 const env = getEnv(process.env);
 
+console.log(env.VERSION)
+
 const getPublicInterfaces = () => {
   const ifaces = os.networkInterfaces();
   return flatMap(Object.values(ifaces))
@@ -26,7 +28,19 @@ const getListeningAddresses = () => {
 
 bootstrapServer(env).then(({ httpServer }) => {
   const server = httpServer.listen(env.PORT, env.HOST, () => {
-    console.log(`\nStarting dungeon-revealer@${env.DR_VERSION} 
+
+    let version_string;
+    if (env.VERSION.status == 'release') {
+      version_string = env.VERSION.appversion;
+    } else if (env.VERSION.status == 'development') {
+      version_string = `${env.VERSION.commit}\nThis development version is ${env.VERSION.commits_ahead} commits ahead of ${env.VERSION.tag}!\n`;
+    } else if (env.VERSION.status == 'unknown') {
+      version_string = `${env.VERSION.appversion}\nI couldn't verify the git commit of this version! I think it is based on ${env.VERSION.appversion}.\n`;
+    } else {
+      console.log(`version: ${env.VERSION}`)
+    }
+
+    console.log(`\nStarting dungeon-revealer@${version_string} 
 
 Configuration:
 - HOST: ${env.HOST} 


### PR DESCRIPTION
This displays a message about the version at runtime based on information gathered at build time from `package.json` and [`git describe --tags`](https://git-scm.com/docs/git-describe#_description). A prebuild script at `scripts/prebuild.js` gathers all the information and writes it to `server/version.ts` with the following structure:
```typescript
export const appversion = '1.16.0';  // Version from package.json.
export const status = 'development';  // status = 'release' || 'development' || 'unknown'
export const tag = 'v1.16.0';  // Version from `git describe --tags`.
export const commit = '60c7b82';  // HEAD commit.
export const commits_ahead = '84';  // How many commits ahead of tag we are.
export const obj = 'g60c7b82';  // Commit-ish object from `git describe --tags`. Currently unused.
```
You can then import it wherever you want. I imported this into `server/env.ts` which then gets passed to `server/index.js` which outputs the following console messages:

- If we're building on a tag (`status = release`):
```
Starting dungeon-revealer@1.16.0 

Configuration:
...
```
- If we're building on a commit (`status = development`):
```
Starting dungeon-revealer@60c7b82
This development version is 84 commits ahead of v1.16.0!
 

Configuration:
...
```
- If something failed, i.e. the git command failed in `scripts/prebuild.js` (`status = unknown`):
```
Starting dungeon-revealer@1.16.0
I couldn't verify the git commit of this version, but I think it's based on 1.16.0.
 

Configuration:
...
```
In this case it still uses the version from `package.json`


----

Related #710 

## TODO
- [x] add version from `package.json` to log output. See [how to get the version from the package json in typescript](https://stackoverflow.com/a/67701490).
- [x] show something else when not on a git tag. Add something using `git describe --tags` in `prebuild` script. 
- [x] possibly use `cross-env` in the `prebuild` script for the Windows folks.
     - [x] Include Windows and Mac in `build-ci.yml`
- [x]  add `.git` to docker build stage (not included in final image)
- [ ] (Admin) update required checks for PRs 