### PR TITLE
Feature/live position

### DIFF
--- a/server/map-lib.ts
+++ b/server/map-lib.ts
@@ -331,6 +331,18 @@ export type MapPing = {
   y: number;
 };
 
+export type MapPosition = {
+  x: number;
+  y: number;
+};
+
+export type MapMove = {
+  id: string;
+  scale: number;
+  position: MapPosition;
+};
+
 export type MapPubSubConfig = {
   mapPing: [id: string, mapPing: MapPing];
+  mapMove: [id: string, mapMove: MapMove];
 };

--- a/src/authenticated-app-shell.tsx
+++ b/src/authenticated-app-shell.tsx
@@ -6,6 +6,7 @@ import { useStaticRef } from "./hooks/use-static-ref";
 import { SplashScreen } from "./splash-screen";
 import { ChatToggleButton, IconButton } from "./chat-toggle-button";
 import { Chat } from "./chat";
+import { SettingsModal } from "./settings-modal/settings-modal";
 import { useChatSoundsAndUnreadCount } from "./chat/chat";
 import { useLogInMutation } from "./chat/log-in-mutation";
 import styled from "@emotion/styled/macro";
@@ -109,6 +110,9 @@ const AuthenticatedAppShellRenderer: React.FC<{ isMapOnly: boolean }> = ({
   }, [logIn]);
 
   const [showSearch, setShowSearch] = React.useState(false);
+  const [showSettings, setShowSettings] = React.useState(false);
+
+  const role = useViewerRole();
 
   React.useEffect(() => {
     if (!isLoggedIn) return;
@@ -170,6 +174,14 @@ const AuthenticatedAppShellRenderer: React.FC<{ isMapOnly: boolean }> = ({
                   >
                     <Icon.Search boxSize="20px" />
                   </IconButton>
+                  {role === "DM" ? (
+                    <IconButton
+                      onClick={() => setShowSettings(true)}
+                      style={{ marginRight: 8, pointerEvents: "all" }}
+                    >
+                      <Icon.Settings boxSize="20px" />
+                    </IconButton>
+                  ) : null}
                   <ChatToggleButton
                     hasUnreadMessages={hasUnreadMessages}
                     onClick={() => {
@@ -197,6 +209,13 @@ const AuthenticatedAppShellRenderer: React.FC<{ isMapOnly: boolean }> = ({
               <React.Suspense fallback={null}>
                 <DiceRollNotes close={toggleShowDiceRollNotes} />
               </React.Suspense>
+            ) : null}
+            {showSettings ? (
+              <SettingsModal
+                close={() => {
+                  setShowSettings(false);
+                }}
+              ></SettingsModal>
             ) : null}
           </React.Fragment>
         ) : null}

--- a/src/dm-area/dm-area.tsx
+++ b/src/dm-area/dm-area.tsx
@@ -27,6 +27,7 @@ import { MapControlInterface } from "../map-view";
 import { useTokenImageUpload } from "./token-image-upload";
 import { dmAreaTokenAddManyMutation } from "./__generated__/dmAreaTokenAddManyMutation.graphql";
 import { dmArea_MapQuery } from "./__generated__/dmArea_MapQuery.graphql";
+import { useGameSettings } from "../game-settings";
 
 const useLoadedMapId = () =>
   usePersistedState<string | null>("loadedMapId", {
@@ -120,6 +121,18 @@ const Content = ({
   socket: Socket;
   password: string;
 }): React.ReactElement => {
+  const gameSettings = useGameSettings();
+
+  const refs = React.useRef({
+    gameSettings,
+  });
+
+  React.useEffect(() => {
+    refs.current = {
+      gameSettings,
+    };
+  });
+
   const [loadedMapId, setLoadedMapId] = useLoadedMapId();
 
   const dmAreaResponse = useQuery<dmArea_MapQuery>(
@@ -246,6 +259,11 @@ const Content = ({
           type: "image/png",
         })
       );
+
+      if (refs.current.gameSettings.value.autoSendMapUpdates) {
+        //Non-blocking send in the event it fails the map will still be saved
+        sendLiveMap(canvas).then(() => {});
+      }
 
       const task = sendRequest({
         url: buildApiUrl(`/map/${loadedMapId}/fog`),

--- a/src/game-settings.tsx
+++ b/src/game-settings.tsx
@@ -2,16 +2,18 @@ import * as React from "react";
 
 interface GameSettings {
   autoSendMapUpdates: boolean;
+  clientsFollowDM: boolean;
 }
 
 const defaultGameSettings: GameSettings = {
   autoSendMapUpdates: false,
+  clientsFollowDM: false,
 };
 
 const getGameSettings = (): GameSettings => {
   const foundGameSettings = window.localStorage.getItem("settings.game");
   if (foundGameSettings) {
-    return JSON.parse(foundGameSettings);
+    return Object.assign(defaultGameSettings, JSON.parse(foundGameSettings));
   }
   return defaultGameSettings;
 };

--- a/src/game-settings.tsx
+++ b/src/game-settings.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+interface GameSettings {
+  autoSendMapUpdates: boolean;
+}
+
+const defaultGameSettings: GameSettings = {
+  autoSendMapUpdates: false,
+};
+
+const getGameSettings = (): GameSettings => {
+  const foundGameSettings = window.localStorage.getItem("settings.game");
+  if (foundGameSettings) {
+    return JSON.parse(foundGameSettings);
+  }
+  return defaultGameSettings;
+};
+
+const writeGameSettings = (gameSettings: GameSettings) => {
+  //write settings to localstorage
+  window.localStorage.setItem("settings.game", JSON.stringify(gameSettings));
+};
+
+type SetFunction = (value: GameSettings) => void;
+
+type ContextType = {
+  value: GameSettings;
+  setValue: SetFunction;
+};
+
+const Context = React.createContext<ContextType>({
+  setValue: writeGameSettings,
+  value: getGameSettings(),
+});
+
+export const GameSettingsProvider: React.FC<{}> = (props) => {
+  const [state, setState] = React.useState<ContextType>(() => ({
+    setValue: (value: GameSettings) => {
+      writeGameSettings(value);
+      setState((state) => ({
+        ...state,
+        value,
+      }));
+    },
+    value: getGameSettings(),
+  }));
+
+  return <Context.Provider value={state}>{props.children}</Context.Provider>;
+};
+
+export const useGameSettings = () => React.useContext(Context);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { globalStyles } from "./global-styles";
 import { Modal } from "./modal";
 import * as UserStyleSheetOrchestrator from "./user-style-sheet-orchestrator";
 import { registerSoundPlayback } from "./register-sound-playback";
+import { GameSettingsProvider } from "./game-settings";
 
 loader.config({
   paths: {
@@ -55,12 +56,14 @@ const main = async () => {
     render(
       <CacheProvider value={emotionCache}>
         <ChakraProvider>
-          <UserStyleSheetOrchestrator.Provider>
-            <Modal.Provider>
-              <Global styles={globalStyles} />
-              {component}
-            </Modal.Provider>
-          </UserStyleSheetOrchestrator.Provider>
+          <GameSettingsProvider>
+            <UserStyleSheetOrchestrator.Provider>
+              <Modal.Provider>
+                <Global styles={globalStyles} />
+                {component}
+              </Modal.Provider>
+            </UserStyleSheetOrchestrator.Provider>
+          </GameSettingsProvider>
         </ChakraProvider>
       </CacheProvider>,
       element

--- a/src/settings-modal/settings-modal.tsx
+++ b/src/settings-modal/settings-modal.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import { Modal, ModalDialogSize } from "../modal";
+import * as Button from "../button";
+import { Checkbox } from "@chakra-ui/react";
+import { useGameSettings } from "../game-settings";
+
+export const SettingsModal = (props: {
+  close: () => void;
+}): React.ReactElement => {
+  let gameSettings = useGameSettings();
+
+  const changeAutoPush = (event: React.ChangeEvent<HTMLInputElement>) => {
+    gameSettings.setValue({ autoSendMapUpdates: event.target.checked });
+  };
+
+  return (
+    <Modal onPressEscape={props.close} onClickOutside={props.close}>
+      <Modal.Dialog size={ModalDialogSize.SMALL}>
+        <Modal.Header>
+          <h3>Game Settings</h3>
+        </Modal.Header>
+        <Modal.Body>
+          <Checkbox
+            isChecked={gameSettings.value.autoSendMapUpdates}
+            onChange={changeAutoPush}
+          >
+            Automatically push fog updates to clients
+          </Checkbox>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Actions>
+            <Modal.ActionGroup>
+              <Button.Tertiary tabIndex={1} onClick={props.close}>
+                Close
+              </Button.Tertiary>
+            </Modal.ActionGroup>
+          </Modal.Actions>
+        </Modal.Footer>
+      </Modal.Dialog>
+    </Modal>
+  );
+};

--- a/src/settings-modal/settings-modal.tsx
+++ b/src/settings-modal/settings-modal.tsx
@@ -11,7 +11,19 @@ export const SettingsModal = (props: {
   let gameSettings = useGameSettings();
 
   const changeAutoPush = (event: React.ChangeEvent<HTMLInputElement>) => {
-    gameSettings.setValue({ autoSendMapUpdates: event.target.checked });
+    gameSettings.setValue(
+      Object.assign(gameSettings.value, {
+        autoSendMapUpdates: event.target.checked,
+      })
+    );
+  };
+
+  const changeDMFollow = (event: React.ChangeEvent<HTMLInputElement>) => {
+    gameSettings.setValue(
+      Object.assign(gameSettings.value, {
+        clientsFollowDM: event.target.checked,
+      })
+    );
   };
 
   return (
@@ -26,6 +38,12 @@ export const SettingsModal = (props: {
             onChange={changeAutoPush}
           >
             Automatically push fog updates to clients
+          </Checkbox>
+          <Checkbox
+            isChecked={gameSettings.value.clientsFollowDM}
+            onChange={changeDMFollow}
+          >
+            Set clients to follow any screen movements the DM makes.
           </Checkbox>
         </Modal.Body>
         <Modal.Footer>

--- a/type-definitions.graphql
+++ b/type-definitions.graphql
@@ -398,6 +398,11 @@ type Mutation {
   Ping a point on the map.
   """
   mapPing(input: MapPingInput!): Boolean
+
+  """
+  Send the DM's current position and scale to the players.
+  """
+  mapMove(input: MapMoveInput!): Boolean
 }
 
 type LogInResult {
@@ -710,6 +715,17 @@ input MapPingInput {
   y: Float!
 }
 
+input MapPositionInput {
+  x: Float!
+  y: Float!
+}
+
+input MapMoveInput {
+  mapId: ID!
+  scale: Float!
+  position: MapPositionInput!
+}
+
 type Subscription {
   userUpdate: UserUpdateSubscription!
   chatMessagesAdded: ChatMessagesAddedSubscription!
@@ -719,6 +735,7 @@ type Subscription {
     hasNextPage: Boolean!
   ): NotesUpdates!
   mapPing(mapId: ID!): MapPing!
+  mapMove(mapId: ID!): MapMove!
 }
 
 union UserUpdateSubscription =
@@ -783,4 +800,15 @@ type MapPing {
   id: ID!
   x: Float!
   y: Float!
+}
+
+type MapPosition {
+  x: Float!
+  y: Float!
+}
+
+type MapMove {
+  id: ID!
+  scale: Float!
+  position: MapPosition!
 }


### PR DESCRIPTION
This supersedes the other PR  #1638. This extends the new settings modal to allow sending live position and scale updates to all attached clients, this closes #207.

In its current form it sends on every change that react-spring which results in higher traffic but very smooth movements, there is a debounce I've left commented out if we wanted a less network heavy approach.

Demo https://youtu.be/BWhQxSx8FuY