### PR TITLE
Fix: actions dep versions and simplify docker deploy

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -29,10 +29,10 @@ jobs:
             output: dungeon-revealer-windows.exe
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -52,7 +52,7 @@ jobs:
           npx caxa -i compile -o ${{ matrix.output }} -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/server-build/index.js" "--caxa"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: artifact-${{ matrix.output }}
           path: "${{ matrix.output }}"
@@ -74,11 +74,11 @@ jobs:
             output: dungeon-revealer-linux-arm64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.docker_platform }}
 
@@ -100,7 +100,7 @@ jobs:
           docker run --rm --platform ${{ matrix.docker_platform }} -v $PWD:/caxa ${{ matrix.docker_image }} sh -c "$CMD"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: artifact-${{ matrix.output }}
           path: ${{ matrix.output }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get branch names
         id: branch-name
@@ -128,7 +128,7 @@ jobs:
           echo "version_string=${{ steps.branch-name.outputs.tag }}" >> $GITHUB_ENV
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: bin/
 
@@ -150,7 +150,7 @@ jobs:
           done
 
       - name: Upload Zip Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dungeon-revealer-zips-${{ env.version_string }}
           path: "bin/*.zip"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.docker_platform }}
 

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [16.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: false

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "16.x"
 
@@ -25,7 +25,7 @@ jobs:
           npm run build
 
       - name: Upload Build App
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: built-app
           path: |
@@ -40,10 +40,10 @@ jobs:
         platform: [linux/amd64, linux/arm/v7, linux/arm64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download built app
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: built-app
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.platform }}
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -120,7 +120,7 @@ jobs:
             --cache-to=type=local,dest=docker-cache/${{ matrix.platform }},mode=max .
 
       - name: Upload local cache to artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-cache
           path: docker-cache
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download built app
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: built-app
 
@@ -147,7 +147,7 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
@@ -156,13 +156,13 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Download local cache artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-cache
           path: docker-cache

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,43 +7,12 @@ on:
       - "v*"
 
 jobs:
-  build-app:
-    name: Build app
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16.x"
-
-      - name: Install
-        run: |
-          npm install
-          npm run build
-
-      - name: Upload Build App
-        uses: actions/upload-artifact@v3
-        with:
-          name: built-app
-          path: |
-            build/**/*
-            server-build/**/*
-
   deploy:
     name: Deploy Images
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Download built app
-        uses: actions/download-artifact@v3
-        with:
-          name: built-app
 
       - name: Set environment
         run: |
@@ -51,6 +20,16 @@ jobs:
           echo "GH_TAG=$TAG" >> $GITHUB_ENV
           echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
           echo "COMMIT_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+
+      - name: Node Install
+        run: |
+          npm install
+          npm run build
 
       - name: Set up QEMU
         id: qemu

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.platform }}
 
@@ -147,7 +147,7 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -31,99 +31,6 @@ jobs:
           path: |
             build/**/*
             server-build/**/*
-  build:
-    name: Build
-    needs: build-app
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm/v7, linux/arm64]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download built app
-        uses: actions/download-artifact@v3
-        with:
-          name: built-app
-
-      - name: Set environment
-        run: |
-          export PLATFORM=${{ matrix.platform }}
-          echo "PLATFORM_DASH=${PLATFORM////-}" >> $GITHUB_ENV
-          echo "BUILD_FAIL=true" >> $GITHUB_ENV
-
-        # ${foo////-} replaces slashes with dashes
-        # foo='linux/arm/v7'
-        # ${foo////-} -> linux-arm-v7
-
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: ${{ matrix.platform }}
-
-      - name: Available platforms
-        run: echo ${{ steps.qemu.outputs.platforms }}
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to DockerHub Registry
-        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-      - name: Run Buildx cache from registry
-        continue-on-error: true
-        run: |
-          docker buildx build \
-            --platform ${{ matrix.platform }} \
-            --output "type=image,push=false" \
-            --build-arg SKIP_BUILD="true" \
-            --cache-from=type=registry,ref=${{ secrets.DOCKER_REPO }}:build-cache-$PLATFORM_DASH \
-            . && echo "BUILD_FAIL=false" >> $GITHUB_ENV
-
-      - name: Run Buildx local build cache
-        if: env.BUILD_FAIL == 'true'
-        continue-on-error: true
-        run: |
-          docker buildx build \
-            --platform ${{ matrix.platform }} \
-            --output "type=image,push=false" \
-            --build-arg SKIP_BUILD="true" \
-            . && echo "BUILD_FAIL=false" >> $GITHUB_ENV
-
-      - name: Run Buildx no cache
-        if: env.BUILD_FAIL == 'true'
-        run: |
-          docker buildx build \
-            --platform ${{ matrix.platform }} \
-            --output "type=image,push=false" \
-            --build-arg SKIP_BUILD="true" \
-            --no-cache .
-
-      - name: Cache to registry
-        continue-on-error: true
-        run: |
-          docker buildx build \
-            --platform ${{ matrix.platform }} \
-            --build-arg SKIP_BUILD="true" \
-            --cache-from=type=registry,ref=${{ secrets.DOCKER_REPO }}:build-cache-$PLATFORM_DASH \
-            --cache-to=type=registry,ref=${{ secrets.DOCKER_REPO }}:build-cache-$PLATFORM_DASH,mode=max .
-
-      - name: Cache to local
-        run: |
-          docker buildx build \
-            --platform ${{ matrix.platform }} \
-            --build-arg SKIP_BUILD="true" \
-            --cache-from=type=registry,ref=${{ secrets.DOCKER_REPO }}:build-cache-$PLATFORM_DASH \
-            --cache-to=type=local,dest=docker-cache/${{ matrix.platform }},mode=max .
-
-      - name: Upload local cache to artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker-cache
-          path: docker-cache
 
   deploy:
     name: Deploy Images
@@ -161,21 +68,12 @@ jobs:
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Download local cache artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-cache
-          path: docker-cache
-
       - name: Run Buildx Dev
         if: startsWith(github.ref, 'refs/heads/') # Just the branches
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
             --output "type=image,push=true" \
-            --cache-from=type=local,src=docker-cache/linux/amd64 \
-            --cache-from=type=local,src=docker-cache/linux/arm/v7 \
-            --cache-from=type=local,src=docker-cache/linux/arm64 \
             --build-arg SKIP_BUILD="true" \
             -t ${{ secrets.DOCKER_REPO }}:dev \
             -t ${{ secrets.DOCKER_REPO }}:$COMMIT \
@@ -198,9 +96,6 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
             --output "type=image,push=true" \
-            --cache-from=type=local,src=docker-cache/linux/amd64 \
-            --cache-from=type=local,src=docker-cache/linux/arm/v7 \
-            --cache-from=type=local,src=docker-cache/linux/arm64 \
             --build-arg SKIP_BUILD="true" \
             -t ${{ secrets.DOCKER_REPO }}:release \
             -t ${{ secrets.DOCKER_REPO }}:$GH_TAG \

--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -13,7 +13,7 @@ jobs:
   deploy-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Fetch merge commit and last commit from pull request
           fetch-depth: 2

--- a/.github/workflows/discord-master-updates.yml
+++ b/.github/workflows/discord-master-updates.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set environment for discord"
         run: |

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set environment: release"
         if: ${{ ! github.event.release.prerelease }} # Only prereleases


### PR DESCRIPTION
This addresses the [Node 12 deprecation warnings for github actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). It also simplifies the docker image deployment as the previous caching strategy was no longer working.