### PR TITLE
Feat: use Github Container Registry instead of Docker Hub

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -71,40 +71,45 @@ jobs:
             ${{ env.DOCKER_REPO }}:dev
             ${{ env.DOCKER_REPO }}:${{ env.COMMIT }}
             ${{ env.DOCKER_REPO }}:${{ env.COMMIT_SHORT }}
+          # NOTE: the image source label below is required to make an image 
+          # publicly accessible in the Github Container Registry.
           labels: |
             org.opencontainers.image.source="https://github.com/${{ github.repository }}"
             org.opencontainers.image.license=ISC
-
-      # - name: Run Buildx Dev
-      #   if: startsWith(github.ref, 'refs/heads/') # Just the branches
-      #   run: |
-      #     docker buildx build \
-      #       --platform linux/amd64,linux/arm/v7,linux/arm64 \
-      #       --output "type=image,push=true" \
-      #       --build-arg SKIP_BUILD="true" \
-      #       -t $DOCKER_REPO:dev \
-      #       -t $DOCKER_REPO:$COMMIT \
-      #       -t $DOCKER_REPO:$COMMIT_SHORT .
 
       - name: Create commit comment
         uses: peter-evans/commit-comment@v1
         if: startsWith(github.ref, 'refs/heads/') # Just the branches
         with:
           body: |
-            **This image has been published to DockerHub.** 🐋   
+            **This commit has been published as a Docker image.** 🐋   
 
             You can easily try this build out locally with Docker.
 
-            `docker run -p 3000:3000 ${{ env.DOCKER_REPO }}:${{ github.sha }}`
+            `docker run -p 3000:3000 ${{ env.DOCKER_REPO }}:${{ env.COMMIT_SHORT }}`
 
-      - name: Run Buildx Release
+      # TODO: refactor this to not repeat all the code in the Dev Release step
+      - name: Version Release
         if: startsWith(github.ref, 'refs/tags/') # Just the tags
-        run: |
-          docker buildx build \
-            --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            --output "type=image,push=true" \
-            --build-arg SKIP_BUILD="true" \
-            -t $DOCKER_REPO:release \
-            -t $DOCKER_REPO:$GH_TAG \
-            -t $DOCKER_REPO:stable \
-            -t $DOCKER_REPO:latest .
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          outputs: |
+            type=registry
+          build-args: |
+            SKIP_BUILD="true"
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+          tags: |
+            ${{ env.DOCKER_REPO }}:release
+            ${{ env.DOCKER_REPO }}:stable
+            ${{ env.DOCKER_REPO }}:latest
+            ${{ env.DOCKER_REPO }}:${{ env.GH_TAG }}
+          # NOTE: the image source label below is required to make an image 
+          # publicly accessible in the Github Container Registry.
+          labels: |
+            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+            org.opencontainers.image.license=ISC

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -57,6 +57,7 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/') # Just the branches
         uses: docker/build-push-action@v4
         with:
+          context: .
           push: true
           outputs: |
             type=registry

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -53,16 +53,37 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Buildx Dev
+      - name: Dev Release
         if: startsWith(github.ref, 'refs/heads/') # Just the branches
-        run: |
-          docker buildx build \
-            --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            --output "type=image,push=true" \
-            --build-arg SKIP_BUILD="true" \
-            -t $DOCKER_REPO:dev \
-            -t $DOCKER_REPO:$COMMIT \
-            -t $DOCKER_REPO:$COMMIT_SHORT .
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          outputs:
+            - type=registry
+          build-args:
+            - SKIP_BUILD="true"
+          platforms:
+            - linux/amd64
+            - linux/arm/v7
+            - linux/arm64
+          tags: 
+            - ${{ env.DOCKER_REPO }}:dev
+            - ${{ env.DOCKER_REPO }}:${{ env.COMMIT }}
+            - ${{ env.DOCKER_REPO }}:${{ env.COMMIT_SHORT }}
+          labels:
+            - org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+            - org.opencontainers.image.license=ISC
+
+      # - name: Run Buildx Dev
+      #   if: startsWith(github.ref, 'refs/heads/') # Just the branches
+      #   run: |
+      #     docker buildx build \
+      #       --platform linux/amd64,linux/arm/v7,linux/arm64 \
+      #       --output "type=image,push=true" \
+      #       --build-arg SKIP_BUILD="true" \
+      #       -t $DOCKER_REPO:dev \
+      #       -t $DOCKER_REPO:$COMMIT \
+      #       -t $DOCKER_REPO:$COMMIT_SHORT .
 
       - name: Create commit comment
         uses: peter-evans/commit-comment@v1
@@ -73,7 +94,7 @@ jobs:
 
             You can easily try this build out locally with Docker.
 
-            `docker run -p 3000:3000 $DOCKER_REPO:${{ github.sha }}`
+            `docker run -p 3000:3000 ${{ env.DOCKER_REPO }}:${{ github.sha }}`
 
       - name: Run Buildx Release
         if: startsWith(github.ref, 'refs/tags/') # Just the tags

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -58,8 +58,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          outputs:
-            - type=registry
+          outputs: type=registry
           build-args:
             - SKIP_BUILD="true"
           platforms:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,6 +20,8 @@ jobs:
           echo "GH_TAG=$TAG" >> $GITHUB_ENV
           echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
           echo "COMMIT_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "DOCKER_REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_ENV
+
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
@@ -44,8 +46,12 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub Registry
-        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Run Buildx Dev
         if: startsWith(github.ref, 'refs/heads/') # Just the branches
@@ -54,9 +60,9 @@ jobs:
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
             --output "type=image,push=true" \
             --build-arg SKIP_BUILD="true" \
-            -t ${{ secrets.DOCKER_REPO }}:dev \
-            -t ${{ secrets.DOCKER_REPO }}:$COMMIT \
-            -t ${{ secrets.DOCKER_REPO }}:$COMMIT_SHORT .
+            -t $DOCKER_REPO:dev \
+            -t $DOCKER_REPO:$COMMIT \
+            -t $DOCKER_REPO:$COMMIT_SHORT .
 
       - name: Create commit comment
         uses: peter-evans/commit-comment@v1
@@ -67,7 +73,7 @@ jobs:
 
             You can easily try this build out locally with Docker.
 
-            `docker run -p 3000:3000 ${{ secrets.DOCKER_REPO }}:${{ github.sha }}`
+            `docker run -p 3000:3000 $DOCKER_REPO:${{ github.sha }}`
 
       - name: Run Buildx Release
         if: startsWith(github.ref, 'refs/tags/') # Just the tags
@@ -76,7 +82,7 @@ jobs:
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
             --output "type=image,push=true" \
             --build-arg SKIP_BUILD="true" \
-            -t ${{ secrets.DOCKER_REPO }}:release \
-            -t ${{ secrets.DOCKER_REPO }}:$GH_TAG \
-            -t ${{ secrets.DOCKER_REPO }}:stable \
-            -t ${{ secrets.DOCKER_REPO }}:latest .
+            -t $DOCKER_REPO:release \
+            -t $DOCKER_REPO:$GH_TAG \
+            -t $DOCKER_REPO:stable \
+            -t $DOCKER_REPO:latest .

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -59,8 +59,7 @@ jobs:
         with:
           push: true
           outputs: type=registry
-          build-args:
-            - SKIP_BUILD="true"
+          build-args: SKIP_BUILD="true"
           platforms:
             - linux/amd64
             - linux/arm/v7

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -58,19 +58,21 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          outputs: type=registry
-          build-args: SKIP_BUILD="true"
-          platforms:
-            - linux/amd64
-            - linux/arm/v7
-            - linux/arm64
-          tags: 
-            - ${{ env.DOCKER_REPO }}:dev
-            - ${{ env.DOCKER_REPO }}:${{ env.COMMIT }}
-            - ${{ env.DOCKER_REPO }}:${{ env.COMMIT_SHORT }}
-          labels:
-            - org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-            - org.opencontainers.image.license=ISC
+          outputs: |
+            type=registry
+          build-args: |
+            SKIP_BUILD="true"
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+          tags: |
+            ${{ env.DOCKER_REPO }}:dev
+            ${{ env.DOCKER_REPO }}:${{ env.COMMIT }}
+            ${{ env.DOCKER_REPO }}:${{ env.COMMIT_SHORT }}
+          labels: |
+            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+            org.opencontainers.image.license=ISC
 
       # - name: Run Buildx Dev
       #   if: startsWith(github.ref, 'refs/heads/') # Just the branches

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Buildx Dev
         if: startsWith(github.ref, 'refs/heads/') # Just the branches

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://img.shields.io/github/workflow/status/dungeon-revealer/dungeon-revealer/Node.js%20CI)](https://github.com/dungeon-revealer/dungeon-revealer/actions)
 [![Downloads](https://img.shields.io/github/downloads/dungeon-revealer/dungeon-revealer/total.svg?logo=github)](https://github.com/dungeon-revealer/dungeon-revealer/releases)
 [![Release](https://img.shields.io/github/v/release/dungeon-revealer/dungeon-revealer?logo=github&color=orange)](https://github.com/dungeon-revealer/dungeon-revealer/releases/latest)
-[![Docker](https://img.shields.io/static/v1?label=docker&message=v1.17.1&color=blue&logo=Docker)](https://hub.docker.com/r/dungeonrevealer/dungeon-revealer/tags?page=1&ordering=last_updated&name=v1.17.1)
+[![Docker](https://img.shields.io/static/v1?label=docker&message=v1.17.1&color=blue&logo=Docker)](https://github.com/dungeon-revealer/dungeon-revealer/pkgs/container/dungeon-revealer/versions)
 [![Discord](https://img.shields.io/discord/709687178422386708)](https://discord.gg/dS5khqk)
 
 Dungeon Revealer is an open source self-hosted app for playing pen and paper such as Dungeon and Dragons or Cyberpunk or other tabletop games together.
@@ -29,7 +29,7 @@ You can protect the DM area by setting a password.
 
 ### Getting the app
 
-The easiest way to use dungeon-revealer is to download the app from the [releases](https://github.com/dungeon-revealer/dungeon-revealer/releases) page here on github. There is also a [docker image](https://hub.docker.com/r/dungeonrevealer/dungeon-revealer) that is kept up to date with the releases in this repository.
+The easiest way to use dungeon-revealer is to download the app from the [releases](https://github.com/dungeon-revealer/dungeon-revealer/releases) page here on github. There is also a [docker image](https://ghcr.io/dungeon-revealer/dungeon-revealer) that is kept up to date with the releases in this repository.
 
 #### Prebuilt app
 
@@ -76,8 +76,8 @@ An up to date version of docker is required to make sure the correct image archi
 To create an instance, run the following:
 
 ```
-docker pull dungeonrevealer/dungeon-revealer:v1.17.1
-docker run -e DM_PASSWORD=<password> -e PC_PASSWORD=<password> -p <PORT>:3000 -v <DATA_DIR>:/usr/src/app/data -d dungeonrevealer/dungeon-revealer:latest
+docker pull ghcr.io/dungeon-revealer/dungeon-revealer:v1.17.1
+docker run -e DM_PASSWORD=<password> -e PC_PASSWORD=<password> -p <PORT>:3000 -v <DATA_DIR>:/usr/src/app/data -d ghcr.io/dungeon-revealer/dungeon-revealer:latest
 ```
 
 - Replace `<password>` with your chosen passwords.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Downloads](https://img.shields.io/github/downloads/dungeon-revealer/dungeon-revealer/total.svg?logo=github)](https://github.com/dungeon-revealer/dungeon-revealer/releases)
 [![Release](https://img.shields.io/github/v/release/dungeon-revealer/dungeon-revealer?logo=github&color=orange)](https://github.com/dungeon-revealer/dungeon-revealer/releases/latest)
 [![Docker](https://img.shields.io/static/v1?label=docker&message=v1.17.1&color=blue&logo=Docker)](https://hub.docker.com/r/dungeonrevealer/dungeon-revealer/tags?page=1&ordering=last_updated&name=v1.17.1)
-[![Docker pulls](https://img.shields.io/docker/pulls/dungeonrevealer/dungeon-revealer)](https://hub.docker.com/r/dungeonrevealer/dungeon-revealer)
 [![Discord](https://img.shields.io/discord/709687178422386708)](https://discord.gg/dS5khqk)
 
 Dungeon Revealer is an open source self-hosted app for playing pen and paper such as Dungeon and Dragons or Cyberpunk or other tabletop games together.

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -1,4 +1,4 @@
-The easiest way to use dungeon-revealer is to download the app from the [releases](https://github.com/dungeon-revealer/dungeon-revealer/releases) page here on github. There is also a [docker image](https://hub.docker.com/r/dungeonrevealer/dungeon-revealer) that is kept up to date with the releases in this repository.
+The easiest way to use dungeon-revealer is to download the app from the [releases](https://github.com/dungeon-revealer/dungeon-revealer/releases) page here on github. There is also a [docker image](https://ghcr.io/dungeon-revealer/dungeon-revealer) that is kept up to date with the releases in this repository.
 
 Running from the command prompt will present connection information and some debugging.
 Optionally, you may set a password for the dungeon master and/or players by setting the environmental variables `DM_PASSWORD` and `PC_PASSWORD` when starting the app. e.g. for linux `PC_PASSWORD='password1' DM_PASSWORD='password2' ./dungeon-revealer-linux`
@@ -40,8 +40,8 @@ An up to date version of docker is required to make sure the correct image archi
 To create an instance, run the following:
 
 ```bash
-docker pull dungeonrevealer/dungeon-revealer:latest
-docker run -e DM_PASSWORD=<password> -e PC_PASSWORD=<password> -p <PORT>:3000 -v <DATA_DIR>:/usr/src/app/data -d dungeonrevealer/dungeon-revealer:latest
+docker pull ghcr.io/dungeon-revealer/dungeon-revealer:latest
+docker run -e DM_PASSWORD=<password> -e PC_PASSWORD=<password> -p <PORT>:3000 -v <DATA_DIR>:/usr/src/app/data -d ghcr.io/dungeon-revealer/dungeon-revealer:latest
 ```
 
 - Replace `<password>` with your chosen passwords.
@@ -56,7 +56,7 @@ Below is an example docker-compose.yml file.
 version: '3'
 services:
   dungeon-revealer:
-    image: dungeonrevealer/dungeon-revealer:latest
+    image: ghcr.io/dungeon-revealer/dungeon-revealer:latest
     container_name: dungeon-revealer
     environment:
       - DM_PASSWORD=<password>


### PR DESCRIPTION
Closes #1650 

### TODO
- [ ] @n1ru4l Delete `DOCKER_*` variables from this repository.
- [ ] After this is merged, make a new release so that we have a working image at GHCR.
- [ ] Decommission our Docker Hub image repo?