### PR TITLE
Fix: deploy wiki to repo owner namespace

### DIFF
--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -38,5 +38,5 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
           MD_FOLDER: wiki/
-          OWNER: dungeon-revealer
+          OWNER: ${{ github.repository_owner }}
           REPO_NAME: dungeon-revealer

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -23,4 +23,3 @@
 ### [Community Showcase](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Community-Showcase)
 
 ### [Contributing](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Contributing)
-

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -23,3 +23,4 @@
 ### [Community Showcase](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Community-Showcase)
 
 ### [Contributing](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Contributing)
+


### PR DESCRIPTION
This makes it so forks aren't trying to deploy to the `dungeon-revealer/dungeon-revealer` wiki but the `fork-owner/dungeon-revealer` wiki.